### PR TITLE
Enable aarch64 SiLabs multiprotocol add-on

### DIFF
--- a/silabs-multiprotocol/README.md
+++ b/silabs-multiprotocol/README.md
@@ -5,6 +5,7 @@ Zigbee/OpenThread Multiprotocol container for Silicon Labs based radios.
 **NOTE:** Requires Silicon Labs based radio with RCP Multi-PAN firmware flashed!
 
 ![Supports armv7 Architecture][armv7-shield]
+![Supports aarch64 Architecture][aarch64-shield]
 
 ## About
 

--- a/silabs-multiprotocol/build.yaml
+++ b/silabs-multiprotocol/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-#  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   armv7: ghcr.io/home-assistant/armv7-base-debian:bullseye

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -5,8 +5,7 @@ description: Zigbee and OpenThread multiprotocol add-on
 url: https://github.com/home-assistant/addons-development/tree/master/silabs-multiprotocol
 arch:
   - armv7
-# Currently zigbeed crashes with *** stack smashing detected ***
-#  - aarch64
+  - aarch64
 hassio_api: true
 # IPC is only used within the Add-on
 host_ipc: false


### PR DESCRIPTION
NOTE: unfortunately not yet ready for prime time.