### PR TITLE
Update to Gecko SDK 4.0.2

### DIFF
--- a/silabs-multiprotocol/CHANGELOG.md
+++ b/silabs-multiprotocol/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0
+- Use Silicon Labs Gecko SDK 4.0.2
+- Enable native aarch64 support
+- Support baudrate and hardware flow control
+
 ## 0.3.1
 
 - Fix permissions to make otbr-agent start correctly

--- a/silabs-multiprotocol/DOCS.md
+++ b/silabs-multiprotocol/DOCS.md
@@ -33,8 +33,8 @@ To use Zigbee with ZHA configure the Integration as follows:
 3. When asked for the Serial Device Path, choose `Enter Manually`.
 4. Choose `EZSP` as Radio type.
 5. As serial path, enter `socket://<hostname-from-above>:9999`.
-6. Choose 115200 as port speed.
-7.  Press `Submit`. Adding ZHA should succeed and you should be able to use ZHA
+6. Port speed and flow control don't matter.
+7. Press `Submit`. Adding ZHA should succeed and you should be able to use ZHA
    as if using any other supported radio type.
 
 ### OpenThread
@@ -59,6 +59,8 @@ Add-on configuration:
 | Configuration      | Description                                            |
 |--------------------|--------------------------------------------------------|
 | device (mandatory) | Serial sevice where the Silicon Labs radio is attached |
+| baudrate           | Serial port baudrate (depends on firmware)   |
+| flow_control       | If hardware flow control should be enabled (depends on firmware) |
 | cpcd_trace         | Co-Processsor Communication tracing (trace in log)     |
 | socat_trace        | ASH/EZSP communication trace (trace in log)            |
 | otbr_enable        | Enable OpenThread BorderRouter                         |

--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -3,9 +3,8 @@ FROM $BUILD_FROM
 
 ARG BUILD_ARCH
 
-ARG CPCD_VERSION=alpha/4.0.1.0
-ARG GECKO_SDK_VERSION=v4.0.1
-ARG SYSTEM_ARCH=arm32v7
+ARG CPCD_VERSION=alpha/4.0.2.0
+ARG GECKO_SDK_VERSION=v4.0.2
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/silabs-multiprotocol/Dockerfile
+++ b/silabs-multiprotocol/Dockerfile
@@ -3,8 +3,8 @@ FROM $BUILD_FROM
 
 ARG BUILD_ARCH
 
-ARG CPCD_VERSION=alpha/4.0.2.0
-ARG GECKO_SDK_VERSION=v4.0.2
+ARG CPCD_VERSION
+ARG GECKO_SDK_VERSION
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/silabs-multiprotocol/README.md
+++ b/silabs-multiprotocol/README.md
@@ -4,7 +4,7 @@ Zigbee/OpenThread Multiprotocol container for Silicon Labs based radios.
 
 **NOTE:** Requires Silicon Labs based radio with RCP Multi-PAN firmware flashed!
 
-![Supports armv7 Architecture][armv7-shield]
+![Supports armv7 Architecture][armv7-shield] ![Supports aarch64 Architecture][aarch64-shield]
 
 ## About
 
@@ -14,3 +14,4 @@ installed to support multiple IEEE 802.15.4 Personal Area Networks (PAN). The
 addon has been tested with EFR32 Series 2 based radios.
 
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+[aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg

--- a/silabs-multiprotocol/build.yaml
+++ b/silabs-multiprotocol/build.yaml
@@ -1,3 +1,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   armv7: ghcr.io/home-assistant/armv7-base-debian:bullseye
+args:
+  CPCD_VERSION: alpha/4.0.2.0
+  GECKO_SDK_VERSION: v4.0.2

--- a/silabs-multiprotocol/build.yaml
+++ b/silabs-multiprotocol/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-#  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
   armv7: ghcr.io/home-assistant/armv7-base-debian:bullseye

--- a/silabs-multiprotocol/config.yaml
+++ b/silabs-multiprotocol/config.yaml
@@ -1,12 +1,11 @@
-version: 0.3.1
+version: 0.4.0
 slug: silabs_multiprotocol
 name: Silicon Labs Multiprotocol
 description: Zigbee and OpenThread multiprotocol add-on
 url: https://github.com/home-assistant/addons-development/tree/master/silabs-multiprotocol
 arch:
   - armv7
-# Currently zigbeed crashes with *** stack smashing detected ***
-#  - aarch64
+  - aarch64
 hassio_api: true
 # IPC is only used within the Add-on
 host_ipc: false
@@ -18,6 +17,8 @@ image: homeassistant/{arch}-addon-silabs-multiprotocol
 init: false
 options:
   device: null
+  baudrate: 115200
+  flow_control: true
   cpcd_trace: false
   socat_trace: false
   otbr_enable: true
@@ -28,6 +29,8 @@ ports_description:
   9999/tcp: EmberZNet EZSP/ASH port
 schema:
   device: device(subsystem=tty)
+  baudrate: list(57600|115200|230400|460800|921600)
+  flow_control: bool
   cpcd_trace: bool
   socat_trace: bool
   otbr_enable: bool

--- a/silabs-multiprotocol/rootfs/etc/cont-init.d/config.sh
+++ b/silabs-multiprotocol/rootfs/etc/cont-init.d/config.sh
@@ -4,6 +4,8 @@
 # ==============================================================================
 
 declare device
+declare baudrate
+declare flow_control
 declare cpcd_trace
 
 if ! bashio::config.has_value 'device'; then
@@ -11,6 +13,18 @@ if ! bashio::config.has_value 'device'; then
     bashio::exit.nok
 fi
 device=$(bashio::config 'device')
+
+if ! bashio::config.has_value 'baudrate'; then
+    bashio::log.fatal "No serial port baudrate set!"
+    bashio::exit.nok
+fi
+baudrate=$(bashio::config 'baudrate')
+
+if  ! bashio::config.has_value 'flow_control'; then
+    flow_control="false"
+else
+    flow_control=$(bashio::config 'flow_control')
+fi
 
 if  ! bashio::config.has_value 'cpcd_trace'; then
     cpcd_trace="false"
@@ -21,6 +35,8 @@ fi
 bashio::log.info "Generating cpcd configuration."
 bashio::var.json \
     device "${device}" \
+    baudrate "${baudrate}" \
+    flow_control "${flow_control}" \
     cpcd_trace "${cpcd_trace}" \
     | tempio \
         -template /usr/local/share/cpcd.conf \

--- a/silabs-multiprotocol/rootfs/etc/services.d/cpcd/run
+++ b/silabs-multiprotocol/rootfs/etc/services.d/cpcd/run
@@ -3,4 +3,5 @@
 # Start Co-Processor Communication Daemon (CPCd)
 # ==============================================================================
 bashio::log.info "Starting cpcd..."
-exec s6-notifyoncheck -d -s 300 -w 300 "/usr/bin/stdbuf" -o0 /usr/local/bin/cpcd
+exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
+    "/usr/bin/stdbuf" -o0 /usr/local/bin/cpcd

--- a/silabs-multiprotocol/rootfs/etc/services.d/otbr-agent/run
+++ b/silabs-multiprotocol/rootfs/etc/services.d/otbr-agent/run
@@ -26,4 +26,5 @@ fi
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."
 
 bashio::log.info "Starting otbr-agent..."
-exec s6-notifyoncheck -d -s 300 -w 300 /usr/sbin/otbr-agent -I wpan0 -B "${backbone_if}" ${otbr_agent_options} -v spinel+cpc://cpcd_0?iid=2
+exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
+    "/usr/sbin/otbr-agent" -I wpan0 -B "${backbone_if}" ${otbr_agent_options} -v spinel+cpc://cpcd_0?iid=2

--- a/silabs-multiprotocol/rootfs/usr/local/etc/cpcd.conf
+++ b/silabs-multiprotocol/rootfs/usr/local/etc/cpcd.conf
@@ -14,15 +14,11 @@ SPI_DEVICE_FILE=/dev/spidev0.0
 
 # SPI CS gpio
 # Chip select gpio selection
-SPI_CS_GPIO=24
+SPI_CS_GPIO=8
 
 # SPI RX IRQ gpio
 # RX interrupt gpio selection
-SPI_RX_IRQ_GPIO=23
-
-# SPI WAKE gpio
-# Wakeup gpio used by the bootloader
-SPI_WAKE_GPIO=25
+SPI_RX_IRQ_GPIO=22
 
 # SPI bitrate.
 # Optional if spi chosen, ignored if uart chosen. Defaults at 1000000
@@ -41,10 +37,25 @@ UART_DEVICE_FILE=/dev/ttyUSB0
 # Allowed values : standard UART baud rates listed in 'termios.h'
 UART_DEVICE_BAUD=115200
 
-# UART flow control (secondaries don't support flow control yet).
+# UART flow control.
 # Optional if uart chosen, ignored if spi chosen. Defaults at 'false'
 # Allowed values are 'true' or 'false'
-UART_HARDFLOW=false
+UART_HARDFLOW=true
+
+# BOOTLOADER Recovery Pins Enabled
+# Set to true to enter bootloader via wake and reset pins
+# If true, SPI_WAKE_GPIO and SPI_RESET_GPIO must be configured
+BOOTLOADER_RECOVERY_PINS_ENABLED=false
+
+# BOOTLOADER WAKE gpio
+# Wakeup gpio used by the bootloader
+# Ensure BOOTLOADER_RECOVERY_PINS_ENABLED=true to use this pin
+BOOTLOADER_WAKE_GPIO=24
+
+# BOOTLOADER RESET gpio
+# Reset pin
+# Ensure BOOTLOADER_RECOVERY_PINS_ENABLED=true to use this pin
+BOOTLOADER_RESET_GPIO=23
 
 # Prints tracing information to stdout
 # Optional, defaults to 'false'
@@ -57,8 +68,14 @@ STDOUT_TRACE=false
 TRACE_TO_FILE=false
 
 # Traces folder
-# Optional, defaults to './cpcd-traces'
-TRACES_FOLDER=./cpcd-traces
+# Optional, defaults to '/dev/shm/cpcd-traces'
+# Folder mounted on a tmpfs is prefered
+TRACES_FOLDER=/dev/shm/cpcd-traces
+
+# Enable frame trace
+# Optional, defaults to 'false'
+# Allowed values are 'true' or 'false'
+ENABLE_FRAME_TRACE=false
 
 # Number of open file descriptors.
 # Optional, defaults at 2000

--- a/silabs-multiprotocol/rootfs/usr/local/share/cpcd.conf
+++ b/silabs-multiprotocol/rootfs/usr/local/share/cpcd.conf
@@ -14,15 +14,11 @@ SPI_DEVICE_FILE=/dev/spidev0.0
 
 # SPI CS gpio
 # Chip select gpio selection
-SPI_CS_GPIO=24
+SPI_CS_GPIO=8
 
 # SPI RX IRQ gpio
 # RX interrupt gpio selection
-SPI_RX_IRQ_GPIO=23
-
-# SPI WAKE gpio
-# Wakeup gpio used by the bootloader
-SPI_WAKE_GPIO=25
+SPI_RX_IRQ_GPIO=22
 
 # SPI bitrate.
 # Optional if spi chosen, ignored if uart chosen. Defaults at 1000000
@@ -39,12 +35,27 @@ UART_DEVICE_FILE={{ .device }}
 # UART baud rate.
 # Optional if uart chosen, ignored if spi chosen. Defaults at 115200
 # Allowed values : standard UART baud rates listed in 'termios.h'
-UART_DEVICE_BAUD=115200
+UART_DEVICE_BAUD={{ .baudrate }}
 
-# UART flow control (secondaries don't support flow control yet).
+# UART flow control.
 # Optional if uart chosen, ignored if spi chosen. Defaults at 'false'
 # Allowed values are 'true' or 'false'
-UART_HARDFLOW=false
+UART_HARDFLOW={{ .flow_control }}
+
+# BOOTLOADER Recovery Pins Enabled
+# Set to true to enter bootloader via wake and reset pins
+# If true, SPI_WAKE_GPIO and SPI_RESET_GPIO must be configured
+BOOTLOADER_RECOVERY_PINS_ENABLED=false
+
+# BOOTLOADER WAKE gpio
+# Wakeup gpio used by the bootloader
+# Ensure BOOTLOADER_RECOVERY_PINS_ENABLED=true to use this pin
+BOOTLOADER_WAKE_GPIO=24
+
+# BOOTLOADER RESET gpio
+# Reset pin
+# Ensure BOOTLOADER_RECOVERY_PINS_ENABLED=true to use this pin
+BOOTLOADER_RESET_GPIO=23
 
 # Prints tracing information to stdout
 # Optional, defaults to 'false'
@@ -57,8 +68,14 @@ STDOUT_TRACE={{ .cpcd_trace }}
 TRACE_TO_FILE=false
 
 # Traces folder
-# Optional, defaults to './cpcd-traces'
-TRACES_FOLDER=./cpcd-traces
+# Optional, defaults to '/dev/shm/cpcd-traces'
+# Folder mounted on a tmpfs is prefered
+TRACES_FOLDER=/dev/shm/cpcd-traces
+
+# Enable frame trace
+# Optional, defaults to 'false'
+# Allowed values are 'true' or 'false'
+ENABLE_FRAME_TRACE=false
 
 # Number of open file descriptors.
 # Optional, defaults at 2000

--- a/silabs-multiprotocol/translations/en.yaml
+++ b/silabs-multiprotocol/translations/en.yaml
@@ -2,6 +2,12 @@ configuration:
   device:
     name: Device
     description: The serial port where the Silicon Labs radio is connected to.
+  baudrate:
+    name: Baudrate
+    description: The serial port baudrate used to communicate with the Silicon Labs radio.
+  flow_control:
+    name: Hardware flow control
+    description: Enable hardware flow control for serial port.
   cpcd_trace:
     name: Co-Processor Communication tracing
     description: Enable tracing for the Co-Processor Communication daemon.


### PR DESCRIPTION
Update the multiprotocol add-on with artefacts released by Silicon Labs
latest Gecko SDK 4.0.2 release. In this release the zigbeed aarch64
version seems to be working, hence the add-on now is also available for
that platform.

Also add options to set baudrate and hardware flow control.