### PR TITLE
Add OTBR firewall support

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+- Support OpenThread Border Router firewall to avoid unnecessary traffic in the
+  OpenThread network.
+
 ## 0.1.4
 - Enable OpenThread diagnostic mode
 

--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -49,6 +49,7 @@ Add-on configuration:
 | baudrate           | Serial port baudrate (depends on firmware)   |
 | flow_control       | If hardware flow control should be enabled (depends on firmware) |
 | otbr_debug         | Start OpenThread BorderRouter Agent with debug log     |
+| firewall           | Enable OpenThread Border Router firewall to block unnecessary traffic |
 
 ## Support
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.2.0
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on
@@ -21,11 +21,13 @@ options:
   baudrate: 115200
   flow_control: false
   otbr_debug: false
+  firewall: true
 schema:
   device: device(subsystem=tty)
   baudrate: list(57600|115200|230400|460800|921600)
   flow_control: bool
   otbr_debug: bool
+  firewall: bool
 stage: experimental
 startup: services
 ingress: true

--- a/openthread_border_router/rootfs/etc/services.d/otbr-agent/finish
+++ b/openthread_border_router/rootfs/etc/services.d/otbr-agent/finish
@@ -3,3 +3,26 @@
 # OpenThread BorderRouter Daemon finish script
 #==============================================================================
 bashio::log.info "otbr-agent ended with exit code ${1} (signal ${2})..."
+
+. common
+
+ipset_destroy_if_exist()
+{
+    if ipset list "$1"; then
+        ipset destroy "$1"
+    fi
+}
+
+while ip6tables -C FORWARD -o $thread_if -j $otbr_forward_ingress_chain; do
+	ip6tables -D FORWARD -o $thread_if -j $otbr_forward_ingress_chain
+done
+
+if ip6tables -L $otbr_forward_ingress_chain; then
+	ip6tables -w -F $otbr_forward_ingress_chain
+	ip6tables -w -X $otbr_forward_ingress_chain
+fi
+
+ipset_destroy_if_exist otbr-ingress-deny-src
+ipset_destroy_if_exist otbr-ingress-deny-src-swap
+ipset_destroy_if_exist otbr-ingress-allow-dst
+ipset_destroy_if_exist otbr-ingress-allow-dst-swap

--- a/openthread_border_router/rootfs/etc/services.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/services.d/otbr-agent/run
@@ -3,6 +3,8 @@
 # OpenThread BorderRouter start script
 # ==============================================================================
 
+. common
+
 declare otbr_agent_options
 declare backbone_if
 declare device
@@ -29,7 +31,24 @@ fi
 
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."
 
+if bashio::config.true 'firewall'; then
+    bashio::log.info "Setup OTBR firewall..."
+    ipset create -exist otbr-ingress-deny-src hash:net family inet6
+    ipset create -exist otbr-ingress-deny-src-swap hash:net family inet6
+    ipset create -exist otbr-ingress-allow-dst hash:net family inet6
+    ipset create -exist otbr-ingress-allow-dst-swap hash:net family inet6
+
+    ip6tables -N $otbr_forward_ingress_chain
+    ip6tables -I FORWARD 1 -o $thread_if -j $otbr_forward_ingress_chain
+
+    ip6tables -A $otbr_forward_ingress_chain -m pkttype --pkt-type unicast -i ${thread_if} -j DROP
+    ip6tables -A $otbr_forward_ingress_chain -m set --match-set otbr-ingress-deny-src src -j DROP
+    ip6tables -A $otbr_forward_ingress_chain -m set --match-set otbr-ingress-allow-dst dst -j ACCEPT
+    ip6tables -A $otbr_forward_ingress_chain -m pkttype --pkt-type unicast -j DROP
+    ip6tables -A $otbr_forward_ingress_chain -j ACCEPT
+fi
+
 bashio::log.info "Starting otbr-agent..."
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
-    "/usr/sbin/otbr-agent" -I wpan0 -B "${backbone_if}" ${otbr_agent_options} \
+    "/usr/sbin/otbr-agent" -I ${thread_if} -B "${backbone_if}" ${otbr_agent_options} \
         "spinel+hdlc+uart://${device}?uart-baudrate=${baudrate}${flow_control}"

--- a/openthread_border_router/translations/en.yaml
+++ b/openthread_border_router/translations/en.yaml
@@ -11,3 +11,6 @@ configuration:
   otbr_debug:
     name: OpenThread agent debugging
     description: Enable OpenThread agent debug output (otbr-agent).
+  firewall:
+    name: OTBR firewall
+    description: Use OpenThread Border Router firewall to block unnecessary traffic.


### PR DESCRIPTION
From OTBR documentation:

OTBR uses iptables and ipset to implement the following ingress filtering
rules:

* Block inbound packets initiated with On-Link address sources, for example
  Off-Mesh Routable (OMR) and Mesh-Local prefix based addresses.
* Block inbound unicast packets whose destination address is not an OMR
  address or a Domain Unicast Address (DUA).
* Block inbound unicast packets whose source address or destination address
  is Link-Local. Note that this rule is handled by the kernel and not
  explicitly set.