### PR TITLE
Bump Python version to 3.10 for custom deps

### DIFF
--- a/custom_deps/CHANGELOG.md
+++ b/custom_deps/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.2
+ - Update Python to 3.10
+
 ## 1.3.1
 
 - Add `--disable-pip-version-check` to the pip install command

--- a/custom_deps/build.yaml
+++ b/custom_deps/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.9-alpine3.14
-  i386: ghcr.io/home-assistant/i386-base-python:3.9-alpine3.14
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.9-alpine3.14
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.9-alpine3.14
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.9-alpine3.14
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.10-alpine3.16
+  i386: ghcr.io/home-assistant/i386-base-python:3.10-alpine3.16
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.10-alpine3.16
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.10-alpine3.16
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.10-alpine3.16

--- a/custom_deps/config.yaml
+++ b/custom_deps/config.yaml
@@ -1,5 +1,5 @@
 name: Custom deps deployment
-version: 1.3.1
+version: 1.3.2
 slug: custom_deps
 description: Manage custom Python modules in Home Assistant deps
 url: https://github.com/home-assistant/hassio-addons-development


### PR DESCRIPTION
Custom deps silently installed to `/config/deps/lib/python3.9/site-packages/` while Python's site directory is expected to be in `python3.10`.

Looks like this was previously done in #66 but the PR was closed due to CLA.