### PR TITLE
openthread_border_router: Adjust IPv6 firewall to allow forwarding

### DIFF
--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.6
+
+- Accept IPv6 forwarding explicitly (required for HAOS 9.x)
+
 ## 0.2.5
 
 - Bump to OTBR POSIX version 110eb2507c (2022-11-24 14:36:14 -0800)

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.6
 
 - Accept IPv6 forwarding explicitly (required for HAOS 9.x)
+- Add egress firewall rules for forwarding if firewall is enabled
 
 ## 0.2.5
 

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,4 +1,4 @@
-version: 0.2.5
+version: 0.2.6
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -27,6 +27,15 @@ ipset_destroy_if_exist otbr-ingress-deny-src-swap
 ipset_destroy_if_exist otbr-ingress-allow-dst
 ipset_destroy_if_exist otbr-ingress-allow-dst-swap
 
+while ip6tables -C FORWARD -i $thread_if -j $otbr_forward_egress_chain 2> /dev/null; do
+	ip6tables -D FORWARD -i $thread_if -j $otbr_forward_egress_chain
+done
+
+if ip6tables -L $otbr_forward_egress_chain 2> /dev/null; then
+	ip6tables -w -F $otbr_forward_egress_chain
+	ip6tables -w -X $otbr_forward_egress_chain
+fi
+
 if test "$1" -eq 256 ; then
   e=$((128 + $2))
 else

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -31,6 +31,11 @@ fi
 
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."
 
+# Make sure ip6tables (as used by Docker) allow IP forwarding
+ip6tables -P FORWARD ACCEPT
+# HAOS 9.3 and earlier (for 9.4 accept is the default so this won't do anything)
+ip6tables-legacy -P FORWARD ACCEPT
+
 if bashio::config.true 'firewall'; then
     bashio::log.info "Setup OTBR firewall..."
     ipset create -exist otbr-ingress-deny-src hash:net family inet6

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -31,11 +31,6 @@ fi
 
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || bashio::exit.nok "Could not create directory /var/lib/thread to store Thread data."
 
-# Make sure ip6tables (as used by Docker) allow IP forwarding
-ip6tables -P FORWARD ACCEPT
-# HAOS 9.3 and earlier (for 9.4 accept is the default so this won't do anything)
-ip6tables-legacy -P FORWARD ACCEPT
-
 if bashio::config.true 'firewall'; then
     bashio::log.info "Setup OTBR firewall..."
     ipset create -exist otbr-ingress-deny-src hash:net family inet6
@@ -51,6 +46,15 @@ if bashio::config.true 'firewall'; then
     ip6tables -A $otbr_forward_ingress_chain -m set --match-set otbr-ingress-allow-dst dst -j ACCEPT
     ip6tables -A $otbr_forward_ingress_chain -m pkttype --pkt-type unicast -j DROP
     ip6tables -A $otbr_forward_ingress_chain -j ACCEPT
+
+    ip6tables -N $otbr_forward_egress_chain
+    ip6tables -I FORWARD 2 -i $thread_if -j $otbr_forward_egress_chain
+    ip6tables -A $otbr_forward_egress_chain -j ACCEPT
+else
+    # Make sure ip6tables (as used by Docker) allow IP forwarding
+    ip6tables -P FORWARD ACCEPT
+    # HAOS 9.3 and earlier (for 9.4 accept is the default so this won't do anything)
+    ip6tables-legacy -P FORWARD ACCEPT
 fi
 
 bashio::log.info "Starting otbr-agent..."

--- a/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
+++ b/openthread_border_router/rootfs/etc/s6-overlay/scripts/otbr-agent-common
@@ -2,6 +2,8 @@
 
 declare thread_if
 declare otbr_forward_ingress_chain
+declare otbr_forward_egress_chain
 thread_if="wpan0"
 otbr_forward_ingress_chain="OTBR_FORWARD_INGRESS"
+otbr_forward_egress_chain="OTBR_FORWARD_EGRESS"
 


### PR DESCRIPTION
With this change,IPv6 forwarding will get globally enabled if the firewall is not active. This allows to use the OTBR on all HAOS versions, also when Docker uses IPv6 (which disables forwarding by default).

If the firewall is active, an egress rule will be created. However, this will only work on HAOS 9.4 or later using iptables with NFT.