### PR TITLE
openthread_border_router: Bump to latest git and add REST API

### DIFF
--- a/openthread_border_router/0001-rest-implement-REST-API-to-get-dataset.patch
+++ b/openthread_border_router/0001-rest-implement-REST-API-to-get-dataset.patch
@@ -1,0 +1,1624 @@
+From 15efb5c0770b705c6ef83b00afe64b3eb80b78df Mon Sep 17 00:00:00 2001
+Message-Id: <15efb5c0770b705c6ef83b00afe64b3eb80b78df.1672239253.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 23 Dec 2022 10:39:34 +0100
+Subject: [PATCH] [rest] implement REST API to get dataset
+
+---
+ src/rest/json.cpp     | 355 +++++++++++++++++++++++++++++++
+ src/rest/json.hpp     |  24 +++
+ src/rest/openapi.yaml | 470 ++++++++++++++++++++++++++++++++++++++++++
+ src/rest/parser.cpp   |  28 ++-
+ src/rest/request.cpp  |  18 ++
+ src/rest/request.hpp  |  40 +++-
+ src/rest/resource.cpp | 176 +++++++++++++---
+ src/rest/resource.hpp |  20 +-
+ src/rest/response.cpp |  10 +-
+ src/rest/response.hpp |   8 +
+ src/rest/types.hpp    |   8 +
+ src/utils/hex.cpp     |  38 ++--
+ src/utils/hex.hpp     |  40 ++++
+ 13 files changed, 1182 insertions(+), 53 deletions(-)
+ create mode 100644 src/rest/openapi.yaml
+
+diff --git a/src/rest/json.cpp b/src/rest/json.cpp
+index 5c9cf90feb..b7d661595c 100644
+--- a/src/rest/json.cpp
++++ b/src/rest/json.cpp
+@@ -27,6 +27,7 @@
+  */
+ 
+ #include "rest/json.hpp"
++#include <sstream>
+ 
+ #include "common/code_utils.hpp"
+ #include "common/types.hpp"
+@@ -114,6 +115,131 @@ static cJSON *IpAddr2Json(const otIp6Address &aAddress)
+     return cJSON_CreateString(addr.ToString().c_str());
+ }
+ 
++static cJSON *IpPrefix2Json(const otIp6NetworkPrefix &aAddress)
++{
++    std::stringstream ss;
++    otIp6Address      address = {};
++
++    address.mFields.mComponents.mNetworkPrefix = aAddress;
++    Ip6Address addr(address.mFields.m8);
++
++    ss << addr.ToString() << "/" << OT_IP6_PREFIX_BITSIZE;
++
++    return cJSON_CreateString(ss.str().c_str());
++}
++
++otbrError Json2IpPrefix(const cJSON *aJson, otIp6NetworkPrefix &aIpPrefix)
++{
++    otbrError          error = OTBR_ERROR_NONE;
++    std::istringstream ipPrefixStr(std::string(aJson->valuestring));
++    std::string        tmp;
++    Ip6Address         addr;
++
++    VerifyOrExit(std::getline(ipPrefixStr, tmp, '/'), error = OTBR_ERROR_INVALID_ARGS);
++    VerifyOrExit((error = addr.FromString(tmp.c_str(), addr)) == OTBR_ERROR_NONE);
++
++    memcpy(aIpPrefix.m8, addr.m8, OT_IP6_PREFIX_SIZE);
++exit:
++    return error;
++}
++
++static cJSON *Timestamp2Json(const otTimestamp &aTimestamp)
++{
++    cJSON *timestamp = cJSON_CreateObject();
++
++    cJSON_AddItemToObject(timestamp, "Seconds", cJSON_CreateNumber(aTimestamp.mSeconds));
++    cJSON_AddItemToObject(timestamp, "Ticks", cJSON_CreateNumber(aTimestamp.mTicks));
++    cJSON_AddItemToObject(timestamp, "Authoritative", cJSON_CreateBool(aTimestamp.mAuthoritative));
++
++    return timestamp;
++}
++
++bool Json2Timestamp(const cJSON *jsonTimestamp, otTimestamp &aTimestamp)
++{
++    cJSON *value;
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonTimestamp, "Seconds");
++    if (cJSON_IsNumber(value))
++    {
++        aTimestamp.mSeconds = static_cast<uint64_t>(value->valuedouble);
++    }
++    else if (value != nullptr)
++    {
++        return false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonTimestamp, "Ticks");
++    if (cJSON_IsNumber(value))
++    {
++        aTimestamp.mTicks = static_cast<uint16_t>(value->valueint);
++    }
++    else if (value != nullptr)
++    {
++        return false;
++    }
++
++    value                     = cJSON_GetObjectItemCaseSensitive(jsonTimestamp, "Authoritative");
++    aTimestamp.mAuthoritative = cJSON_IsTrue(value);
++
++    return true;
++}
++
++static cJSON *SecurityPolicy2Json(const otSecurityPolicy &aSecurityPolicy)
++{
++    cJSON *securityPolicy = cJSON_CreateObject();
++
++    cJSON_AddItemToObject(securityPolicy, "RotationTime", cJSON_CreateNumber(aSecurityPolicy.mRotationTime));
++    cJSON_AddItemToObject(securityPolicy, "ObtainNetworkKey",
++                          cJSON_CreateBool(aSecurityPolicy.mObtainNetworkKeyEnabled));
++    cJSON_AddItemToObject(securityPolicy, "NativeCommissioning",
++                          cJSON_CreateBool(aSecurityPolicy.mNativeCommissioningEnabled));
++    cJSON_AddItemToObject(securityPolicy, "Routers", cJSON_CreateBool(aSecurityPolicy.mRoutersEnabled));
++    cJSON_AddItemToObject(securityPolicy, "ExternalCommissioning",
++                          cJSON_CreateBool(aSecurityPolicy.mExternalCommissioningEnabled));
++    cJSON_AddItemToObject(securityPolicy, "CommercialCommissioning",
++                          cJSON_CreateBool(aSecurityPolicy.mCommercialCommissioningEnabled));
++    cJSON_AddItemToObject(securityPolicy, "AutonomousEnrollment",
++                          cJSON_CreateBool(aSecurityPolicy.mAutonomousEnrollmentEnabled));
++    cJSON_AddItemToObject(securityPolicy, "NetworkKeyProvisioning",
++                          cJSON_CreateBool(aSecurityPolicy.mNetworkKeyProvisioningEnabled));
++    cJSON_AddItemToObject(securityPolicy, "TobleLink", cJSON_CreateBool(aSecurityPolicy.mTobleLinkEnabled));
++    cJSON_AddItemToObject(securityPolicy, "NonCcmRouters", cJSON_CreateBool(aSecurityPolicy.mNonCcmRoutersEnabled));
++
++    return securityPolicy;
++}
++
++bool Json2SecurityPolicy(const cJSON *jsonSecurityPolicy, otSecurityPolicy &aSecurityPolicy)
++{
++    cJSON *value;
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "RotationTime");
++    if (cJSON_IsNumber(value))
++    {
++        aSecurityPolicy.mRotationTime = static_cast<uint16_t>(value->valueint);
++    }
++
++    value                                    = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "ObtainNetworkKey");
++    aSecurityPolicy.mObtainNetworkKeyEnabled = cJSON_IsTrue(value);
++    value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NativeCommissioning");
++    aSecurityPolicy.mNativeCommissioningEnabled = cJSON_IsTrue(value);
++    value                                       = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "Routers");
++    aSecurityPolicy.mRoutersEnabled             = cJSON_IsTrue(value);
++    value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "ExternalCommissioning");
++    aSecurityPolicy.mExternalCommissioningEnabled = cJSON_IsTrue(value);
++    value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "CommercialCommissioning");
++    aSecurityPolicy.mCommercialCommissioningEnabled = cJSON_IsTrue(value);
++    value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "AutonomousEnrollment");
++    aSecurityPolicy.mAutonomousEnrollmentEnabled = cJSON_IsTrue(value);
++    value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NetworkKeyProvisioning");
++    aSecurityPolicy.mNetworkKeyProvisioningEnabled = cJSON_IsTrue(value);
++    value                                          = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "TobleLink");
++    aSecurityPolicy.mTobleLinkEnabled              = cJSON_IsTrue(value);
++    value                                 = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NonCcmRouters");
++    aSecurityPolicy.mNonCcmRoutersEnabled = cJSON_IsTrue(value);
++
++    return true;
++}
++
+ static cJSON *ChildTableEntry2Json(const otNetworkDiagChildEntry &aChildEntry)
+ {
+     cJSON *childEntry = cJSON_CreateObject();
+@@ -482,6 +608,235 @@ std::string Error2JsonString(HttpStatusCode aErrorCode, std::string aErrorMessag
+     return ret;
+ }
+ 
++std::string Dataset2JsonString(const otOperationalDataset &aDataset)
++{
++    cJSON      *node = cJSON_CreateObject();
++    std::string ret;
++
++    if (aDataset.mComponents.mIsActiveTimestampPresent)
++    {
++        cJSON_AddItemToObject(node, "ActiveTimestamp", Timestamp2Json(aDataset.mActiveTimestamp));
++    }
++    if (aDataset.mComponents.mIsPendingTimestampPresent)
++    {
++        cJSON_AddItemToObject(node, "PendingTimestamp", Timestamp2Json(aDataset.mPendingTimestamp));
++    }
++    if (aDataset.mComponents.mIsNetworkKeyPresent)
++    {
++        cJSON_AddItemToObject(node, "NetworkKey", Bytes2HexJson(aDataset.mNetworkKey.m8, OT_NETWORK_KEY_SIZE));
++    }
++    if (aDataset.mComponents.mIsNetworkNamePresent)
++    {
++        cJSON_AddItemToObject(node, "NetworkName", cJSON_CreateString(aDataset.mNetworkName.m8));
++    }
++    if (aDataset.mComponents.mIsExtendedPanIdPresent)
++    {
++        cJSON_AddItemToObject(node, "ExtPanId", Bytes2HexJson(aDataset.mExtendedPanId.m8, OT_EXT_PAN_ID_SIZE));
++    }
++    if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
++    {
++        cJSON_AddItemToObject(node, "MeshLocalPrefix", IpPrefix2Json(aDataset.mMeshLocalPrefix));
++    }
++    if (aDataset.mComponents.mIsDelayPresent)
++    {
++        cJSON_AddItemToObject(node, "Delay", cJSON_CreateNumber(aDataset.mDelay));
++    }
++    if (aDataset.mComponents.mIsPanIdPresent)
++    {
++        cJSON_AddItemToObject(node, "PanId", cJSON_CreateNumber(aDataset.mPanId));
++    }
++    if (aDataset.mComponents.mIsChannelPresent)
++    {
++        cJSON_AddItemToObject(node, "Channel", cJSON_CreateNumber(aDataset.mChannel));
++    }
++    if (aDataset.mComponents.mIsPskcPresent)
++    {
++        cJSON_AddItemToObject(node, "PSKc", Bytes2HexJson(aDataset.mPskc.m8, OT_PSKC_MAX_SIZE));
++    }
++    if (aDataset.mComponents.mIsSecurityPolicyPresent)
++    {
++        cJSON_AddItemToObject(node, "SecurityPolicy", SecurityPolicy2Json(aDataset.mSecurityPolicy));
++    }
++    if (aDataset.mComponents.mIsChannelMaskPresent)
++    {
++        cJSON_AddItemToObject(node, "ChannelMask", cJSON_CreateNumber(aDataset.mChannelMask));
++    }
++
++    ret = Json2String(node);
++    cJSON_Delete(node);
++
++    return ret;
++}
++
++bool JsonString2Dataset(const std::string &aJsonDataset, otOperationalDataset &aDataset)
++{
++    cJSON      *value;
++    cJSON      *jsonDataset;
++    otTimestamp timestamp;
++    bool        ret = true;
++
++    VerifyOrExit((jsonDataset = cJSON_Parse(aJsonDataset.c_str())) != nullptr, ret = false);
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "ActiveTimestamp");
++    if (cJSON_IsObject(value))
++    {
++        VerifyOrExit(Json2Timestamp(value, timestamp), ret = false);
++        aDataset.mActiveTimestamp                      = timestamp;
++        aDataset.mComponents.mIsActiveTimestampPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsActiveTimestampPresent = false;
++    }
++    else if (value != nullptr)
++    {
++        ExitNow(ret = false);
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "PendingTimestamp");
++    if (cJSON_IsObject(value))
++    {
++        VerifyOrExit(Json2Timestamp(value, timestamp), ret = false);
++        aDataset.mPendingTimestamp                      = timestamp;
++        aDataset.mComponents.mIsPendingTimestampPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsPendingTimestampPresent = false;
++    }
++    else if (value != nullptr)
++    {
++        ExitNow(ret = false);
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "NetworkKey");
++    if (cJSON_IsString(value))
++    {
++        VerifyOrExit(value->valuestring != nullptr, ret = false);
++        VerifyOrExit(Hex2BytesJsonString(std::string(value->valuestring), aDataset.mNetworkKey.m8,
++                                         OT_NETWORK_KEY_SIZE) == OT_NETWORK_KEY_SIZE,
++                     ret = false);
++        aDataset.mComponents.mIsNetworkKeyPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsNetworkKeyPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "NetworkName");
++    if (cJSON_IsString(value))
++    {
++        VerifyOrExit(value->valuestring != nullptr, ret = false);
++        VerifyOrExit(strlen(value->valuestring) <= OT_NETWORK_NAME_MAX_SIZE, ret = false);
++        strncpy(aDataset.mNetworkName.m8, value->valuestring, OT_NETWORK_NAME_MAX_SIZE);
++        aDataset.mComponents.mIsNetworkNamePresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsNetworkNamePresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "ExtPanId");
++    if (cJSON_IsString(value))
++    {
++        VerifyOrExit(value->valuestring != nullptr, ret = false);
++        VerifyOrExit(Hex2BytesJsonString(std::string(value->valuestring), aDataset.mExtendedPanId.m8,
++                                         OT_EXT_PAN_ID_SIZE) == OT_EXT_PAN_ID_SIZE,
++                     ret = false);
++        aDataset.mComponents.mIsExtendedPanIdPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsExtendedPanIdPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "MeshLocalPrefix");
++    if (cJSON_IsString(value))
++    {
++        VerifyOrExit(value->valuestring != nullptr, ret = false);
++        VerifyOrExit(Json2IpPrefix(value, aDataset.mMeshLocalPrefix) == OTBR_ERROR_NONE, ret = false);
++        aDataset.mComponents.mIsMeshLocalPrefixPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsMeshLocalPrefixPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "Delay");
++    if (cJSON_IsNumber(value))
++    {
++        aDataset.mDelay                      = value->valueint;
++        aDataset.mComponents.mIsDelayPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsDelayPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "PanId");
++    if (cJSON_IsNumber(value))
++    {
++        aDataset.mPanId                      = static_cast<otPanId>(value->valueint);
++        aDataset.mComponents.mIsPanIdPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsPanIdPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "Channel");
++    if (cJSON_IsNumber(value))
++    {
++        aDataset.mChannel                      = static_cast<uint16_t>(value->valueint);
++        aDataset.mComponents.mIsChannelPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsChannelPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "PSKc");
++    if (cJSON_IsString(value))
++    {
++        VerifyOrExit(value->valuestring != nullptr, ret = false);
++        VerifyOrExit(Hex2BytesJsonString(std::string(value->valuestring), aDataset.mPskc.m8, OT_PSKC_MAX_SIZE) ==
++                         OT_PSKC_MAX_SIZE,
++                     ret = false);
++        aDataset.mComponents.mIsPskcPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsPskcPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "SecurityPolicy");
++    if (cJSON_IsObject(value))
++    {
++        VerifyOrExit(Json2SecurityPolicy(value, aDataset.mSecurityPolicy), ret = false);
++        aDataset.mComponents.mIsSecurityPolicyPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsSecurityPolicyPresent = false;
++    }
++
++    value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "ChannelMask");
++    if (cJSON_IsNumber(value))
++    {
++        aDataset.mChannelMask                      = value->valueint;
++        aDataset.mComponents.mIsChannelMaskPresent = true;
++    }
++    else if (cJSON_IsNull(value))
++    {
++        aDataset.mComponents.mIsChannelMaskPresent = false;
++    }
++
++exit:
++    cJSON_Delete(jsonDataset);
++
++    return ret;
++}
++
+ } // namespace Json
+ } // namespace rest
+ } // namespace otbr
+diff --git a/src/rest/json.hpp b/src/rest/json.hpp
+index e9fd178201..86d92c42ec 100644
+--- a/src/rest/json.hpp
++++ b/src/rest/json.hpp
+@@ -34,6 +34,7 @@
+ #ifndef OTBR_REST_JSON_HPP_
+ #define OTBR_REST_JSON_HPP_
+ 
++#include "openthread/dataset.h"
+ #include "openthread/link.h"
+ #include "openthread/thread_ftd.h"
+ 
+@@ -213,6 +214,29 @@ std::string ChildTableEntry2JsonString(const otNetworkDiagChildEntry &aChildEntr
+  */
+ std::string Error2JsonString(HttpStatusCode aErrorCode, std::string aErrorMessage);
+ 
++/**
++ * This method formats a Json object from a dataset.
++ *
++ * @param[in] aDataset  A dataset struct.
++ *
++ * @returns A string of serialized Json object.
++ *
++ */
++std::string Dataset2JsonString(const otOperationalDataset &aDataset);
++
++/**
++ * This method parses a Json string and fills the provided dataset. Fields
++ * set to null are cleared (set to not present). Non-present fields are left
++ * as is.
++ *
++ * @param[in] aJsonDataset  The Json string to be parsed.
++ * @param[in] aDataset      The dataset struct to be filled.
++ *
++ * @returns If the Json string has been successfully parsed.
++ *
++ */
++bool JsonString2Dataset(const std::string &aJsonDataset, otOperationalDataset &aDataset);
++
+ }; // namespace Json
+ 
+ } // namespace rest
+diff --git a/src/rest/openapi.yaml b/src/rest/openapi.yaml
+new file mode 100644
+index 0000000000..e4b23ca297
+--- /dev/null
++++ b/src/rest/openapi.yaml
+@@ -0,0 +1,470 @@
++openapi: 3.0.3
++info:
++  title: Swagger OpenThread REST API
++  description: |-
++    This describes the OpenThread Border Router REST API. The API is provided by the otbr-agent, if the cmake flag `OTBR_REST=ON` is set. By default
++    the REST API listens on any address on port 8081.
++
++    Some useful links:
++    - [OpenThread Border Router repository](github.com/openthread/ot-br-posix/)
++  license:
++    name: BSD 3-Clause
++    url: https://github.com/openthread/ot-br-posix/blob/main/LICENSE
++  version: 0.3.0
++servers:
++  - url: http://localhost:8081
++tags:
++  - name: node
++    description: Thread parameters of this node.
++  - name: diagnostics
++    description: Thread network diagnostic.
++paths:
++  /diagnostics:
++    get:
++      tags:
++        - diagnostics
++      summary: Get Thread network diagnostics
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: object
++  /node:
++    get:
++      tags:
++        - node
++      summary: Get current active node parameters
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: object
++  /node/rloc:
++    get:
++      tags:
++        - node
++      summary: Routing Locator IPv6 address of this Thread node.
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: string
++                description: RLOC IPv6 address
++                example: "fda4:728e:4b39:bc4a:0:ff:fe00:1000"
++  /node/rloc16:
++    get:
++      tags:
++        - node
++      summary: Routing Locator Router and Child ID (RLOC16).
++      description: Last 16-bit of the Routing Locator IPv6 consisting of the Router ID and a Child ID.
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: number
++                description: RLOC16 address
++                example: 4096
++  /node/ext-address:
++    get:
++      tags:
++        - node
++      summary: IEEE 802.15.4 Extended Address (EUI-64).
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: string
++                description: 8-byte IEEE 802.15.4 Extended Address of this node as hex string.
++                example: "C21F906BE0352A4C"
++  /node/state:
++    get:
++      tags:
++        - node
++      summary: Get current Thread state.
++      description: |-
++        State describing the current Thread role of this Thread node.
++        - 0: disabled
++        - 1: detached
++        - 2: child
++        - 3: router
++        - 4: leader
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: number
++                description: Current state
++                example: 4
++  /node/network-name:
++    get:
++      tags:
++        - node
++      summary: Thread network name this node is part of.
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: string
++                description: Thread network name.
++                example: "OpenThread-e445"
++  /node/leader-data:
++    get:
++      tags:
++        - node
++      summary: Gets the network's leader data.
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/LeaderData"
++  /node/ext-panid:
++    get:
++      tags:
++        - node
++      summary: Extended PAN ID.
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: string
++                description: 8-byte extended PAN ID as hex string.
++                example: "3CAB144450CF407E"
++  /node/num-of-router:
++    get:
++      tags:
++        - node
++      summary: Get number of router devices
++      responses:
++        "200":
++          description: Successful operation
++          content:
++            application/json:
++              schema:
++                type: number
++                description: Number of routers
++                example: 1
++  /node/dataset/active:
++    get:
++      tags:
++        - node
++      summary: Get current active operational dataset
++      responses:
++        "200":
++          description: Returns currently active operational dataset
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/Dataset"
++            text/plain:
++              schema:
++                $ref: "#/components/schemas/DatasetTlv"
++        "204":
++          description: No active operational dataset
++    post:
++      tags:
++        - node
++      summary: Create new active operational dataset
++      description: |-
++        Creates new active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
++        pending dataset if you would like to change the current active operational dataset if the Thread node is active.
++
++        Default parameters are chosen for parameters not set in the request body.
++      requestBody:
++        description: |-
++          Operational dataset object that will be stored as active operational dataset. JSON keys which are not set will be initialized with
++          default or random values.
++        content:
++          application/json:
++            schema:
++              $ref: "#/components/schemas/Dataset"
++      responses:
++        "202":
++          description: Successfully created the active operational dataset.
++        "400":
++          description: Invalid request body.
++        "409":
++          description: Writing active operational dataset rejected because Thread network is active.
++    put:
++      tags:
++        - node
++      summary: Update current active operational dataset
++      description: |-
++        Updates the current active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
++        pending dataset if you would like to change the current active operational dataset if the Thread node is active.
++      requestBody:
++        description: |-
++          Operational dataset object that will be stored as active operational dataset. Supports request body Content-Type `text/plain`
++          (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
++          initialized with default or random values).
++        content:
++          application/json:
++            schema:
++              $ref: "#/components/schemas/Dataset"
++          plain/text:
++            schema:
++              $ref: "#/components/schemas/DatasetTlv"
++      responses:
++        "202":
++          description: Successfully updated the active operational dataset.
++        "400":
++          description: Invalid request body.
++        "404":
++          description: No active operational dataset to update.
++        "409":
++          description: Writing active operational dataset rejected because Thread network is active.
++  /node/dataset/pending:
++    get:
++      tags:
++        - node
++      summary: Get current pending operational dataset
++      responses:
++        "200":
++          description: Returns currently pending operational dataset
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/Dataset"
++            text/plain:
++              schema:
++                $ref: "#/components/schemas/DatasetTlv"
++        "204":
++          description: No pending operational dataset
++    post:
++      tags:
++        - node
++      summary: Create new pending operational dataset
++      description: |-
++        Creates new pending operational dataset on the current node. If the delay timer is specified, the new pending operational dataset
++        will become active after the time elapsed. The pending dataset will become empty.
++
++        Default parameters are chosen for parameters not set in the request body. By default, the delay timer is *not* set.
++
++        Note: To be considered as a valid active operational dataset the ActiveTimestamp needs to be newer than the current active operational
++        dataset.
++      requestBody:
++        description: |-
++          Operational dataset object that will be stored as pending operational dataset. JSON keys which are not set will be initialized with
++          default or random values.
++        content:
++          application/json:
++            schema:
++              $ref: "#/components/schemas/Dataset"
++      responses:
++        "202":
++          description: Successfully created the active operational dataset.
++        "400":
++          description: Invalid request body.
++    put:
++      tags:
++        - node
++      summary: Update current pending operational dataset
++      description: |-
++        Updates the current pending operational dataset on the current node.
++      requestBody:
++        description: |-
++          Operational dataset object that will be stored as pending operational dataset. Supports request body Content-Type `text/plain`
++          (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
++          initialized with default or random values).
++        content:
++          application/json:
++            schema:
++              $ref: "#/components/schemas/Dataset"
++          plain/text:
++            schema:
++              $ref: "#/components/schemas/DatasetTlv"
++      responses:
++        "202":
++          description: Successfully updated the pending operational dataset.
++        "400":
++          description: Invalid request body.
++        "404":
++          description: No pending operational dataset to update.
++components:
++  schemas:
++    LeaderData:
++      type: object
++      properties:
++        PartitionId:
++          type: number
++          format: uint32
++          description: Partition ID
++          example: 1230046604
++        Weighting:
++          type: number
++          format: uint8
++          description: Leader Weight
++          example: 64
++        DataVersion:
++          type: number
++          description: Full network data version
++          example: 244
++        StableDataVersion:
++          type: number
++          format: uint8
++          description: Stable Network Data Version
++          example: 186
++        LeaderRouterId:
++          type: number
++          format: uint8
++          description: Leader Router ID
++          example: 4
++    Dataset:
++      type: object
++      properties:
++        ActiveTimestamp:
++          $ref: "#/components/schemas/Timestamp"
++        PendingTimestamp:
++          $ref: "#/components/schemas/Timestamp"
++        NetworkKey:
++          type: string
++          description: Network key, 16 bytes long, formatted as a hexadecimal string
++          example: 08277229F21FB7342D705D3CEFDC042A
++          default: random
++        NetworkName:
++          type: string
++          description: Network name, 16 bytes long
++          example: OpenThread-e445
++          default: OpenThread-<PanId>
++        ExtPanId:
++          type: string
++          description: Extended PAN ID, 8 bytes long, formatted as a hexadecimal string
++          example: 996D3BEE320097A3
++          default: random
++        MeshLocalPrefix:
++          type: string
++          description: Mesh local IPv6 prefix
++          example: fd33:d3b9:89e3:72e4::/64
++          default: random
++        Delay:
++          type: integer
++          description: Delay timer in milliseconds
++          format: uint32
++          example: 30000
++          default: not set
++        PanId:
++          type: integer
++          description: IEEE 802.15.4 PAN ID of the Thread network
++          format: uint16
++          example: 58437
++          default: random
++        Channel:
++          type: integer
++          description: IEEE 802.15.4 channel of the Thread network
++          format: uint16
++          example: 21
++          default: random
++        PSKc:
++          type: string
++          description: The pre-shared commissioner key
++          example: FD943ECA225A28979B991EFAC1218A72
++          default: random
++        SecurityPolicy:
++          $ref: "#/components/schemas/SecurityPolicy"
++        ChannelMask:
++          type: integer
++          description: Channel mask
++          format: uint32
++          example: 134215680
++          default: 134215680
++    SecurityPolicy:
++      type: object
++      properties:
++        RotationTime:
++          type: integer
++          description: Thread key rotation time in hours
++          format: uint16
++          example: 672
++          default: 672
++        ObtainNetworkKey:
++          type: boolean
++          description: Obtaining the Network Key for out-of-band commissioning is enabled
++          example: true
++          default: true
++        NativeCommissioning:
++          type: boolean
++          description: Native Commissioning using PSKc is allowed
++          example: true
++          default: true
++        Routers:
++          type: boolean
++          description: Thread 1.0/1.1.x Routers are enabled
++          example: true
++          default: true
++        ExternalCommissioning:
++          type: boolean
++          description: External Commissioner authentication is allowed
++          example: true
++          default: true
++        CommercialCommissioning:
++          type: boolean
++          description: Commercial Commissioning is enabled
++          example: false
++          default: false
++        AutonomousEnrollment:
++          type: boolean
++          description: Autonomous Enrollment is enabled
++          example: false
++          default: false
++        NetworkKeyProvisioning:
++          type: boolean
++          description: Network Key Provisioning is enabled
++          example: false
++          default: false
++        TobleLink:
++          type: boolean
++          description: ToBLE link is enabled
++          example: false
++          default: false
++        NonCcmRouters:
++          type: boolean
++          description: Non-CCM Routers enabled
++          example: false
++          default: false
++    Timestamp:
++      type: object
++      properties:
++        Seconds:
++          type: integer
++          description: Timestamp seconds
++          format: uint64
++          example: 10
++          default: 1
++        Ticks:
++          type: integer
++          description: Timestamp ticks
++          format: uint16
++          example: 0
++          default: 0
++        Authoritative:
++          type: boolean
++          example: false
++          default: false
++    DatasetTlv:
++      type: string
++      description: Operational dataset as hex-encoded TLVs.
++      example: 0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BFE5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F010212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F8
++  requestBodies:
++    Dataset:
++      description: Operational dataset object that will be stored
++      content:
++        application/json:
++          schema:
++            $ref: "#/components/schemas/Dataset"
+diff --git a/src/rest/parser.cpp b/src/rest/parser.cpp
+index 566f88cbb2..9401e4d0d5 100644
+--- a/src/rest/parser.cpp
++++ b/src/rest/parser.cpp
+@@ -87,6 +87,30 @@ static int OnHandlerData(http_parser *, const char *, size_t)
+     return 0;
+ }
+ 
++static int OnHeaderField(http_parser *parser, const char *at, size_t len)
++{
++    Request *request = reinterpret_cast<Request *>(parser->data);
++
++    if (len > 0)
++    {
++        request->SetNextHeaderField(at, len);
++    }
++
++    return 0;
++}
++
++static int OnHeaderData(http_parser *parser, const char *at, size_t len)
++{
++    Request *request = reinterpret_cast<Request *>(parser->data);
++
++    if (len > 0)
++    {
++        request->SetHeaderValue(at, len);
++    }
++
++    return 0;
++}
++
+ Parser::Parser(Request *aRequest)
+ {
+     mParser.data = aRequest;
+@@ -97,8 +121,8 @@ void Parser::Init(void)
+     mSettings.on_message_begin    = OnMessageBegin;
+     mSettings.on_url              = OnUrl;
+     mSettings.on_status           = OnHandlerData;
+-    mSettings.on_header_field     = OnHandlerData;
+-    mSettings.on_header_value     = OnHandlerData;
++    mSettings.on_header_field     = OnHeaderField;
++    mSettings.on_header_value     = OnHeaderData;
+     mSettings.on_body             = OnBody;
+     mSettings.on_headers_complete = OnHeaderComplete;
+     mSettings.on_message_complete = OnMessageComplete;
+diff --git a/src/rest/request.cpp b/src/rest/request.cpp
+index ac3dc300c3..50a84bed76 100644
+--- a/src/rest/request.cpp
++++ b/src/rest/request.cpp
+@@ -27,6 +27,7 @@
+  */
+ 
+ #include "rest/request.hpp"
++#include "utils/string_utils.hpp"
+ 
+ namespace otbr {
+ namespace rest {
+@@ -56,6 +57,16 @@ void Request::SetMethod(int32_t aMethod)
+     mMethod = aMethod;
+ }
+ 
++void Request::SetNextHeaderField(const char *aString, size_t aLength)
++{
++    mNextHeaderField = StringUtils::ToLowercase(std::string(aString, aLength));
++}
++
++void Request::SetHeaderValue(const char *aString, size_t aLength)
++{
++    mHeaders[mNextHeaderField] = std::string(aString, aLength);
++}
++
+ HttpMethod Request::GetMethod() const
+ {
+     return static_cast<HttpMethod>(mMethod);
+@@ -87,6 +98,13 @@ exit:
+     return url;
+ }
+ 
++std::string Request::GetHeaderValue(const std::string aHeaderField) const
++{
++    auto it = mHeaders.find(StringUtils::ToLowercase(aHeaderField));
++
++    return (it == mHeaders.end()) ? "" : it->second;
++}
++
+ void Request::SetReadComplete(void)
+ {
+     mComplete = true;
+diff --git a/src/rest/request.hpp b/src/rest/request.hpp
+index 63380f0080..5b73b06736 100644
+--- a/src/rest/request.hpp
++++ b/src/rest/request.hpp
+@@ -34,8 +34,8 @@
+ #ifndef OTBR_REST_REQUEST_HPP_
+ #define OTBR_REST_REQUEST_HPP_
+ 
++#include <map>
+ #include <string>
+-#include <vector>
+ 
+ #include "common/code_utils.hpp"
+ #include "rest/types.hpp"
+@@ -90,6 +90,24 @@ public:
+      */
+     void SetMethod(int32_t aMethod);
+ 
++    /**
++     * This method sets the next header field of a request.
++     *
++     * @param[in] aString  A pointer points to body string.
++     * @param[in] aLength  Length of the body string
++     *
++     */
++    void SetNextHeaderField(const char *aString, size_t aLength);
++
++    /**
++     * This method sets the header value of the previously set header of a request.
++     *
++     * @param[in] aString  A pointer points to body string.
++     * @param[in] aLength  Length of the body string
++     *
++     */
++    void SetHeaderValue(const char *aString, size_t aLength);
++
+     /**
+      * This method labels the request as complete which means it no longer need to be parsed one more time .
+      *
+@@ -123,6 +141,14 @@ public:
+      */
+     std::string GetUrl(void) const;
+ 
++    /**
++     * This method returns the specified header field for this request.
++     *
++     * @param[in] aHeaderField  A header field.
++     * @returns A string contains the header value of this request.
++     */
++    std::string GetHeaderValue(const std::string aHeaderField) const;
++
+     /**
+      * This method indicates whether this request is parsed completely.
+      *
+@@ -131,11 +157,13 @@ public:
+     bool IsComplete(void) const;
+ 
+ private:
+-    int32_t     mMethod;
+-    size_t      mContentLength;
+-    std::string mUrl;
+-    std::string mBody;
+-    bool        mComplete;
++    int32_t                            mMethod;
++    size_t                             mContentLength;
++    std::string                        mUrl;
++    std::string                        mBody;
++    std::string                        mNextHeaderField;
++    std::map<std::string, std::string> mHeaders;
++    bool                               mComplete;
+ };
+ 
+ } // namespace rest
+diff --git a/src/rest/resource.cpp b/src/rest/resource.cpp
+index a6a86337bc..be1565881b 100644
+--- a/src/rest/resource.cpp
++++ b/src/rest/resource.cpp
+@@ -45,7 +45,8 @@
+ #define OT_REST_RESOURCE_PATH_NODE_LEADERDATA "/node/leader-data"
+ #define OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER "/node/num-of-router"
+ #define OT_REST_RESOURCE_PATH_NODE_EXTPANID "/node/ext-panid"
+-#define OT_REST_RESOURCE_PATH_NODE_ACTIVE_DATASET_TLVS "/node/active-dataset-tlvs"
++#define OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE "/node/dataset/active"
++#define OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING "/node/dataset/pending"
+ #define OT_REST_RESOURCE_PATH_NETWORK "/networks"
+ #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT "/networks/current"
+ #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_COMMISSION "/networks/commission"
+@@ -53,10 +54,12 @@
+ 
+ #define OT_REST_HTTP_STATUS_200 "200 OK"
+ #define OT_REST_HTTP_STATUS_202 "202 Accepted"
++#define OT_REST_HTTP_STATUS_204 "204 No Content"
+ #define OT_REST_HTTP_STATUS_400 "400 Bad Request"
+ #define OT_REST_HTTP_STATUS_404 "404 Not Found"
+ #define OT_REST_HTTP_STATUS_405 "405 Method Not Allowed"
+ #define OT_REST_HTTP_STATUS_408 "408 Request Timeout"
++#define OT_REST_HTTP_STATUS_409 "409 Conflict"
+ #define OT_REST_HTTP_STATUS_500 "500 Internal Server Error"
+ 
+ using std::chrono::duration_cast;
+@@ -93,6 +96,9 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
+     case HttpStatusCode::kStatusAccepted:
+         httpStatus = OT_REST_HTTP_STATUS_202;
+         break;
++    case HttpStatusCode::kStatusNoContent:
++        httpStatus = OT_REST_HTTP_STATUS_204;
++        break;
+     case HttpStatusCode::kStatusBadRequest:
+         httpStatus = OT_REST_HTTP_STATUS_400;
+         break;
+@@ -105,6 +111,9 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
+     case HttpStatusCode::kStatusRequestTimeout:
+         httpStatus = OT_REST_HTTP_STATUS_408;
+         break;
++    case HttpStatusCode::kStatusConflict:
++        httpStatus = OT_REST_HTTP_STATUS_409;
++        break;
+     case HttpStatusCode::kStatusInternalServerError:
+         httpStatus = OT_REST_HTTP_STATUS_500;
+         break;
+@@ -127,8 +136,9 @@ Resource::Resource(ControllerOpenThread *aNcp)
+     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_LEADERDATA, &Resource::LeaderData);
+     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER, &Resource::NumOfRoute);
+     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_EXTPANID, &Resource::ExtendedPanId);
+-    mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_ACTIVE_DATASET_TLVS, &Resource::ActiveDatasetTlvs);
+     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_RLOC, &Resource::Rloc);
++    mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, &Resource::DatasetActive);
++    mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, &Resource::DatasetPending);
+ 
+     // Resource callback handler
+     mResourceCallbackMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::HandleDiagnosticCallback);
+@@ -499,68 +509,170 @@ void Resource::Rloc(const Request &aRequest, Response &aResponse) const
+     }
+ }
+ 
+-void Resource::GetActiveDatasetTlvs(Response &aResponse) const
++void Resource::GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
+ {
+-    otOperationalDatasetTlvs datasetTlvs;
+-    otError                  error = OT_ERROR_NONE;
++    otbrError                error = OTBR_ERROR_NONE;
++    struct NodeInfo          node;
+     std::string              body;
+     std::string              errorCode;
++    otOperationalDataset     dataset;
++    otOperationalDatasetTlvs datasetTlvs;
+ 
+-    SuccessOrExit(error = otDatasetGetActiveTlvs(mInstance, &datasetTlvs));
++    if (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER) == OT_REST_CONTENT_TYPE_PLAIN)
++    {
++        if (aDatasetType == DatasetType::kActive)
++        {
++            VerifyOrExit(otDatasetGetActiveTlvs(mInstance, &datasetTlvs) == OT_ERROR_NONE,
++                         error = OTBR_ERROR_NOT_FOUND);
++        }
++        else if (aDatasetType == DatasetType::kPending)
++        {
++            VerifyOrExit(otDatasetGetPendingTlvs(mInstance, &datasetTlvs) == OT_ERROR_NONE,
++                         error = OTBR_ERROR_NOT_FOUND);
++        }
+ 
+-    body = Json::Bytes2HexJsonString(datasetTlvs.mTlvs, datasetTlvs.mLength);
++        aResponse.SetContentType(OT_REST_CONTENT_TYPE_PLAIN);
++        body = Utils::Bytes2Hex(datasetTlvs.mTlvs, datasetTlvs.mLength);
++    }
++    else
++    {
++        if (aDatasetType == DatasetType::kActive)
++        {
++            VerifyOrExit(otDatasetGetActive(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
++        }
++        else if (aDatasetType == DatasetType::kPending)
++        {
++            VerifyOrExit(otDatasetGetPending(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
++        }
++        body = Json::Dataset2JsonString(dataset);
++    }
+ 
+     aResponse.SetBody(body);
+-    errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+-    aResponse.SetResponsCode(errorCode);
+ 
+ exit:
+-    if (error != OT_ERROR_NONE)
++    if (error == OTBR_ERROR_NONE)
++    {
++        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
++        aResponse.SetResponsCode(errorCode);
++    }
++    else if (error == OTBR_ERROR_NOT_FOUND)
++    {
++        errorCode = GetHttpStatus(HttpStatusCode::kStatusNoContent);
++        aResponse.SetResponsCode(errorCode);
++    }
++    else
+     {
+-        otbrLogWarning("Failed to get active dataset: %s", otThreadErrorToString(error));
+         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+     }
+ }
+ 
+-void Resource::SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const
++void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const
+ {
+-    int                      ret;
+-    otOperationalDatasetTlvs datasetTlvs;
+-    otError                  error = OT_ERROR_NONE;
++    otbrError                error = OTBR_ERROR_NONE;
++    struct NodeInfo          node;
++    std::string              body;
+     std::string              errorCode;
++    otOperationalDataset     dataset;
++    otOperationalDatasetTlvs datasetTlvs;
++    int                      ret;
++    bool                     isText;
++
++    isText = aRequest.GetHeaderValue(OT_REST_CONTENT_TYPE_HEADER) == OT_REST_CONTENT_TYPE_PLAIN;
+ 
+-    ret = Json::Hex2BytesJsonString(aRequest.GetBody(), datasetTlvs.mTlvs, OT_OPERATIONAL_DATASET_MAX_LENGTH);
+-    if (ret < 0)
++    if (aDatasetType == DatasetType::kActive)
+     {
+-        errorCode = GetHttpStatus(HttpStatusCode::kStatusBadRequest);
+-        aResponse.SetResponsCode(errorCode);
+-        ExitNow();
++        otbrLogWarning("STate is %d", otThreadGetDeviceRole(mInstance));
++        VerifyOrExit(otThreadGetDeviceRole(mInstance) == OT_DEVICE_ROLE_DISABLED, error = OTBR_ERROR_INVALID_STATE);
+     }
+-    datasetTlvs.mLength = ret;
+ 
+-    SuccessOrExit(error = otDatasetSetActiveTlvs(mInstance, &datasetTlvs));
++    if (isText)
++    {
++        // Only PUT allowed for text/plain
++        VerifyOrExit(!create, error = OTBR_ERROR_INVALID_ARGS);
++        ret = Json::Hex2BytesJsonString(aRequest.GetBody(), datasetTlvs.mTlvs, OT_OPERATIONAL_DATASET_MAX_LENGTH);
++        VerifyOrExit(ret >= 0, error = OTBR_ERROR_INVALID_ARGS);
++        datasetTlvs.mLength = ret;
++
++        if (aDatasetType == DatasetType::kActive)
++        {
++            VerifyOrExit(otDatasetSetActiveTlvs(mInstance, &datasetTlvs) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
++        }
++        else if (aDatasetType == DatasetType::kPending)
++        {
++            VerifyOrExit(otDatasetSetPendingTlvs(mInstance, &datasetTlvs) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
++        }
++    }
++    else
++    {
++        if (create)
++        {
++            VerifyOrExit(otDatasetCreateNewNetwork(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
++        }
++        else
++        {
++            if (aDatasetType == DatasetType::kActive)
++            {
++                VerifyOrExit(otDatasetGetActive(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
++            }
++            else if (aDatasetType == DatasetType::kPending)
++            {
++                VerifyOrExit(otDatasetGetPending(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
++            }
++        }
++
++        VerifyOrExit(Json::JsonString2Dataset(aRequest.GetBody(), dataset), error = OTBR_ERROR_INVALID_ARGS);
++
++        if (aDatasetType == DatasetType::kActive)
++        {
++            VerifyOrExit(otDatasetSetActive(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
++        }
++        else if (aDatasetType == DatasetType::kPending)
++        {
++            VerifyOrExit(otDatasetSetPending(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
++        }
++    }
+ 
+     errorCode = GetHttpStatus(HttpStatusCode::kStatusAccepted);
+     aResponse.SetResponsCode(errorCode);
++
+ exit:
+-    if (error != OT_ERROR_NONE)
++    if (error == OTBR_ERROR_INVALID_ARGS)
++    {
++        ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
++    }
++    else if (error == OTBR_ERROR_NOT_FOUND)
++    {
++        ErrorHandler(aResponse, HttpStatusCode::kStatusResourceNotFound);
++    }
++    else if (error == OTBR_ERROR_INVALID_STATE)
++    {
++        ErrorHandler(aResponse, HttpStatusCode::kStatusConflict);
++    }
++    else if (error != OTBR_ERROR_NONE)
+     {
+-        otbrLogWarning("Failed to set active dataset: %s", otThreadErrorToString(error));
+         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+     }
+ }
+ 
+-void Resource::ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const
++void Resource::Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
+ {
+     std::string errorCode;
+ 
+     switch (aRequest.GetMethod())
+     {
+     case HttpMethod::kGet:
+-        GetActiveDatasetTlvs(aResponse);
++        GetDataset(aDatasetType, aRequest, aResponse);
++        break;
++    case HttpMethod::kPost:
++        SetDataset(aDatasetType, aRequest, aResponse, true);
+         break;
+     case HttpMethod::kPut:
+-        SetActiveDatasetTlvs(aRequest, aResponse);
++        SetDataset(aDatasetType, aRequest, aResponse, false);
++        break;
++    case HttpMethod::kOptions:
++        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
++        aResponse.SetResponsCode(errorCode);
++        aResponse.SetComplete();
+         break;
+     default:
+         ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
+@@ -568,6 +680,16 @@ void Resource::ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) c
+     }
+ }
+ 
++void Resource::DatasetActive(const Request &aRequest, Response &aResponse) const
++{
++    Dataset(DatasetType::kActive, aRequest, aResponse);
++}
++
++void Resource::DatasetPending(const Request &aRequest, Response &aResponse) const
++{
++    Dataset(DatasetType::kPending, aRequest, aResponse);
++}
++
+ void Resource::DeleteOutDatedDiagnostic(void)
+ {
+     auto eraseIt = mDiagSet.begin();
+diff --git a/src/rest/resource.hpp b/src/rest/resource.hpp
+index 057cafc3de..2afab72933 100644
+--- a/src/rest/resource.hpp
++++ b/src/rest/resource.hpp
+@@ -39,6 +39,8 @@
+ #include <openthread/border_router.h>
+ 
+ #include "ncp/ncp_openthread.hpp"
++#include "openthread/dataset.h"
++#include "openthread/dataset_ftd.h"
+ #include "rest/json.hpp"
+ #include "rest/request.hpp"
+ #include "rest/response.hpp"
+@@ -102,6 +104,16 @@ public:
+     void ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) const;
+ 
+ private:
++    /**
++     * This enumeration represents the Dataset type (active or pending).
++     *
++     */
++    enum class DatasetType : uint8_t
++    {
++        kActive,  ///< Active Dataset
++        kPending, ///< Pending Dataset
++    };
++
+     typedef void (Resource::*ResourceHandler)(const Request &aRequest, Response &aResponse) const;
+     typedef void (Resource::*ResourceCallbackHandler)(const Request &aRequest, Response &aResponse);
+     void NodeInfo(const Request &aRequest, Response &aResponse) const;
+@@ -113,7 +125,9 @@ private:
+     void Rloc16(const Request &aRequest, Response &aResponse) const;
+     void ExtendedPanId(const Request &aRequest, Response &aResponse) const;
+     void Rloc(const Request &aRequest, Response &aResponse) const;
+-    void ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
++    void Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
++    void DatasetActive(const Request &aRequest, Response &aResponse) const;
++    void DatasetPending(const Request &aRequest, Response &aResponse) const;
+     void Diagnostic(const Request &aRequest, Response &aResponse) const;
+     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
+ 
+@@ -126,8 +140,8 @@ private:
+     void GetDataRloc16(Response &aResponse) const;
+     void GetDataExtendedPanId(Response &aResponse) const;
+     void GetDataRloc(Response &aResponse) const;
+-    void GetActiveDatasetTlvs(Response &aResponse) const;
+-    void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
++    void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
++    void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const;
+ 
+     void DeleteOutDatedDiagnostic(void);
+     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);
+diff --git a/src/rest/response.cpp b/src/rest/response.cpp
+index 2cdfc80ea5..17ae97e384 100644
+--- a/src/rest/response.cpp
++++ b/src/rest/response.cpp
+@@ -30,12 +30,11 @@
+ 
+ #include <stdio.h>
+ 
+-#define OT_REST_RESPONSE_CONTENT_TYPE_JSON "application/json"
+ #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN "*"
+ #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
+     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
+     "Access-Control-Request-Headers"
+-#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET"
++#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, POST, PUT"
+ 
+ namespace otbr {
+ namespace rest {
+@@ -48,7 +47,7 @@ Response::Response(void)
+     mProtocol = "HTTP/1.1 ";
+ 
+     // Pre-defined headers
+-    mHeaders["Content-Type"]                 = OT_REST_RESPONSE_CONTENT_TYPE_JSON;
++    mHeaders[OT_REST_CONTENT_TYPE_HEADER]    = OT_REST_CONTENT_TYPE_JSON;
+     mHeaders["Access-Control-Allow-Origin"]  = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
+     mHeaders["Access-Control-Allow-Methods"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
+     mHeaders["Access-Control-Allow-Headers"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
+@@ -79,6 +78,11 @@ void Response::SetResponsCode(std::string &aCode)
+     mCode = aCode;
+ }
+ 
++void Response::SetContentType(const std::string &aContentType)
++{
++    mHeaders[OT_REST_CONTENT_TYPE_HEADER] = aContentType;
++}
++
+ void Response::SetCallback(void)
+ {
+     mCallback = true;
+diff --git a/src/rest/response.hpp b/src/rest/response.hpp
+index 8ae24ffe30..a7cb73e372 100644
+--- a/src/rest/response.hpp
++++ b/src/rest/response.hpp
+@@ -86,6 +86,14 @@ public:
+      */
+     void SetResponsCode(std::string &aCode);
+ 
++    /**
++     * This method sets the content type.
++     *
++     * @param[in] aCode  A string representing response content type such as text/plain.
++     *
++     */
++    void SetContentType(const std::string &aContentType);
++
+     /**
+      * This method labels the response as need callback.
+      *
+diff --git a/src/rest/types.hpp b/src/rest/types.hpp
+index addc7d2cbb..e1e048237d 100644
+--- a/src/rest/types.hpp
++++ b/src/rest/types.hpp
+@@ -40,6 +40,12 @@
+ 
+ #include "openthread/netdiag.h"
+ 
++#define OT_REST_ACCEPT_HEADER "Accept"
++#define OT_REST_CONTENT_TYPE_HEADER "Content-Type"
++
++#define OT_REST_CONTENT_TYPE_JSON "application/json"
++#define OT_REST_CONTENT_TYPE_PLAIN "text/plain"
++
+ using std::chrono::steady_clock;
+ 
+ namespace otbr {
+@@ -60,10 +66,12 @@ enum class HttpStatusCode : std::uint16_t
+ {
+     kStatusOk                  = 200,
+     kStatusAccepted            = 202,
++    kStatusNoContent           = 204,
+     kStatusBadRequest          = 400,
+     kStatusResourceNotFound    = 404,
+     kStatusMethodNotAllowed    = 405,
+     kStatusRequestTimeout      = 408,
++    kStatusConflict            = 409,
+     kStatusInternalServerError = 500,
+ };
+ 
+diff --git a/src/utils/hex.cpp b/src/utils/hex.cpp
+index 5e82a0b819..397c70d464 100644
+--- a/src/utils/hex.cpp
++++ b/src/utils/hex.cpp
+@@ -96,34 +96,48 @@ size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
+ {
+     char byteHex[3];
+ 
+-    std::string hexString;
+-    uint8_t     cur[aBytesLength];
+-
+-    memcpy(cur, aBytes, aBytesLength);
++    // Make sure strcat appends at the beginning of the output buffer even
++    // if uninitialized.
++    aHex[0] = '\0';
+ 
+     for (int i = 0; i < aBytesLength; i++)
+     {
+-        sprintf(byteHex, "%02X", cur[i]);
+-        hexString += byteHex;
++        sprintf(byteHex, "%02X", aBytes[i]);
++        strcat(aHex, byteHex);
+     }
+-    strcpy(aHex, hexString.c_str());
++
+     return strlen(aHex);
+ }
+ 
++std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength)
++{
++    char        hex[2 * aBytesLength + 1];
++    std::string s;
++    size_t      len;
++
++    len = Bytes2Hex(aBytes, aBytesLength, hex);
++    s   = std::string(hex, len);
++
++    return s;
++}
++
+ size_t Long2Hex(const uint64_t aLong, char *aHex)
+ {
+-    std::string hexString;
+-    char        byteHex[3];
+-    uint64_t    longValue = aLong;
++    char     byteHex[3];
++    uint64_t longValue = aLong;
++
++    // Make sure strcat appends at the beginning of the output buffer even
++    // if uninitialized.
++    aHex[0] = '\0';
+ 
+     for (uint8_t i = 0; i < sizeof(uint64_t); i++)
+     {
+         uint8_t byte = longValue & 0xff;
+         sprintf(byteHex, "%02X", byte);
+-        hexString += byteHex;
++        strcat(aHex, byteHex);
+         longValue = longValue >> 8;
+     }
+-    strcpy(aHex, hexString.c_str());
++
+     return strlen(aHex);
+ }
+ 
+diff --git a/src/utils/hex.hpp b/src/utils/hex.hpp
+index 0aa4b23946..49ba37d561 100644
+--- a/src/utils/hex.hpp
++++ b/src/utils/hex.hpp
+@@ -36,6 +36,8 @@
+ 
+ #include "openthread-br/config.h"
+ 
++#include <string>
++
+ #include <stddef.h>
+ #include <stdint.h>
+ 
+@@ -43,10 +45,48 @@ namespace otbr {
+ 
+ namespace Utils {
+ 
++/**
++ * @brief Converts a hexadecimal string to a byte array.
++ *
++ * @param hexString A pointer to the hexadecimal string to be converted.
++ * @param bytes A pointer to an array to store the resulting byte values.
++ * @param maxBytesLength The maximum number of bytes that can be stored in the `bytes` array.
++ *
++ * @return The number of bytes stored in the `bytes` array, or -1 if an error occurred.
++ */
+ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength);
+ 
++/**
++ * @brief Converts a byte array to a hexadecimal string.
++ *
++ * @param[in]  aBytes A pointer to the byte array to be converted.
++ * @param[in]  aBytesLength The length of the byte array.
++ * @param[out] aHex A character array to store the resulting hexadecimal string.
++ *                  Must be at least 2 * @param aBytesLength + 1 long.
++ *
++ * @return The length of the resulting hexadecimal string.
++ */
+ size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex);
+ 
++/**
++ * @brief Converts a byte array to a hexadecimal string.
++ *
++ * @param[in]  aBytes A pointer to the byte array to be converted.
++ * @param[in]  aBytesLength The length of the byte array.
++ *
++ * @return The hexadecimal string.
++ */
++std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength);
++
++/**
++ * @brief Converts a 64-bit integer to a hexadecimal string.
++ *
++ * @param[in]  aLong The 64-bit integer to be converted.
++ * @param[out] aHex A character array to store the resulting hexadecimal string.
++ *                  Must be at least 17 bytes long.
++ *
++ * @return The length of the resulting hexadecimal string.
++ */
+ size_t Long2Hex(const uint64_t aLong, char *aHex);
+ 
+ } // namespace Utils
+-- 
+2.39.0
+

--- a/openthread_border_router/0002-rest-support-state-change.patch
+++ b/openthread_border_router/0002-rest-support-state-change.patch
@@ -1,0 +1,129 @@
+From 5f94ed4f5e23d168ea4b7351ba66578c137a0e6d Mon Sep 17 00:00:00 2001
+Message-Id: <5f94ed4f5e23d168ea4b7351ba66578c137a0e6d.1672239253.git.stefan@agner.ch>
+In-Reply-To: <15efb5c0770b705c6ef83b00afe64b3eb80b78df.1672239253.git.stefan@agner.ch>
+References: <15efb5c0770b705c6ef83b00afe64b3eb80b78df.1672239253.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Wed, 28 Dec 2022 11:46:25 +0100
+Subject: [PATCH] [rest] support state change
+
+---
+ src/rest/openapi.yaml | 16 +++++++++++++
+ src/rest/resource.cpp | 54 ++++++++++++++++++++++++++++++++++++++++---
+ src/rest/resource.hpp |  1 +
+ 3 files changed, 68 insertions(+), 3 deletions(-)
+
+diff --git a/src/rest/openapi.yaml b/src/rest/openapi.yaml
+index e4b23ca297..36c30245fd 100644
+--- a/src/rest/openapi.yaml
++++ b/src/rest/openapi.yaml
+@@ -107,6 +107,22 @@ paths:
+                 type: number
+                 description: Current state
+                 example: 4
++    post:
++      tags:
++        - node
++      summary: Set current Thread state.
++      description: Allow to enable the network interface and Thread
++      responses:
++        "200":
++          description: Successful operation.
++      requestBody:
++        description: New Thread state
++        content:
++          application/json:
++            schema:
++              type: string
++              description: Can be "enable" or "disable".
++              example: "enable"
+   /node/network-name:
+     get:
+       tags:
+diff --git a/src/rest/resource.cpp b/src/rest/resource.cpp
+index be1565881b..c5dc5f01d2 100644
+--- a/src/rest/resource.cpp
++++ b/src/rest/resource.cpp
+@@ -312,17 +312,65 @@ void Resource::GetDataState(Response &aResponse) const
+     aResponse.SetResponsCode(errorCode);
+ }
+ 
+-void Resource::State(const Request &aRequest, Response &aResponse) const
++void Resource::SetDataState(const Request &aRequest, Response &aResponse) const
+ {
++    otbrError error = OTBR_ERROR_NONE;
+     std::string errorCode;
++    std::string body = aRequest.GetBody();
+ 
+-    if (aRequest.GetMethod() == HttpMethod::kGet)
++    if (body == "\"enable\"")
+     {
+-        GetDataState(aResponse);
++        if (!otIp6IsEnabled(mInstance))
++            SuccessOrExit(otIp6SetEnabled(mInstance, true));
++        VerifyOrExit(otThreadSetEnabled(mInstance, true) == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
++    }
++    else if (body == "\"disable\"")
++    {
++        VerifyOrExit(otThreadSetEnabled(mInstance, false) == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
+     }
+     else
+     {
++        ExitNow(error = OTBR_ERROR_INVALID_ARGS);
++    }
++
++    errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
++    aResponse.SetResponsCode(errorCode);
++
++exit:
++    if (error == OTBR_ERROR_INVALID_STATE)
++    {
++        ErrorHandler(aResponse, HttpStatusCode::kStatusConflict);
++    }
++    if (error == OTBR_ERROR_INVALID_ARGS)
++    {
++        ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
++    }
++    else if (error != OTBR_ERROR_NONE)
++    {
++        ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
++    }
++}
++
++void Resource::State(const Request &aRequest, Response &aResponse) const
++{
++    std::string errorCode;
++
++    switch (aRequest.GetMethod())
++    {
++    case HttpMethod::kGet:
++        GetDataState(aResponse);
++        break;
++    case HttpMethod::kPost:
++        SetDataState(aRequest, aResponse);
++        break;
++    case HttpMethod::kOptions:
++        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
++        aResponse.SetResponsCode(errorCode);
++        aResponse.SetComplete();
++        break;
++    default:
+         ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
++        break;
+     }
+ }
+ 
+diff --git a/src/rest/resource.hpp b/src/rest/resource.hpp
+index 2afab72933..3a0c9a3c85 100644
+--- a/src/rest/resource.hpp
++++ b/src/rest/resource.hpp
+@@ -134,6 +134,7 @@ private:
+     void GetNodeInfo(Response &aResponse) const;
+     void GetDataExtendedAddr(Response &aResponse) const;
+     void GetDataState(Response &aResponse) const;
++    void SetDataState(const Request &aRequest, Response &aResponse) const;
+     void GetDataNetworkName(Response &aResponse) const;
+     void GetDataLeaderData(Response &aResponse) const;
+     void GetDataNumOfRoute(Response &aResponse) const;
+-- 
+2.39.0
+

--- a/openthread_border_router/CHANGELOG.md
+++ b/openthread_border_router/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+- Bump to OTBR POSIX version 079bbce34a (2022-12-22 19:00:41 -0800)
+- Add REST API with full active and pending dataset as well as state support
+- Avoid start error in case multiple primary interfaces are returned
+- Add fine grained OTBR log level control
+- Fix service stop (finish) scripts
+
 ## 0.2.6
 
 - Accept IPv6 forwarding explicitly (required for HAOS 9.x)

--- a/openthread_border_router/DOCS.md
+++ b/openthread_border_router/DOCS.md
@@ -48,7 +48,7 @@ Add-on configuration:
 | device (mandatory) | Serial port where the OpenThread RCP Radio is attached |
 | baudrate           | Serial port baudrate (depends on firmware)   |
 | flow_control       | If hardware flow control should be enabled (depends on firmware) |
-| otbr_debug         | Start OpenThread BorderRouter Agent with debug log     |
+| otbr_log_level     | Set the log level of the OpenThread BorderRouter Agent     |
 | firewall           | Enable OpenThread Border Router firewall to block unnecessary traffic |
 
 ## Support

--- a/openthread_border_router/Dockerfile
+++ b/openthread_border_router/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ARG BUILD_ARCH
 
-ARG OTBR_VERSION=110eb2507caa2fbc9b10935d37f78f6280de1086
+ARG OTBR_VERSION=079bbce34ad7868e2879a8e70550c6ae638d6bac
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -18,6 +18,8 @@ ENV REST_API 1
 ENV DOCKER 1
 
 COPY 0001-Avoid-writing-to-system-console.patch /usr/src
+COPY 0001-rest-implement-REST-API-to-get-dataset.patch /usr/src
+COPY 0002-rest-support-state-change.patch /usr/src
 
 # Required and installed (script/bootstrap) can be removed after build
 ENV OTBR_BUILD_DEPS build-essential ninja-build cmake wget ca-certificates \
@@ -48,6 +50,8 @@ RUN \
     && git checkout ${OTBR_VERSION} \
     && git submodule update --init \
     && ./script/bootstrap \
+    && patch -p1 < /usr/src/0001-rest-implement-REST-API-to-get-dataset.patch \
+    && patch -p1 < /usr/src/0002-rest-support-state-change.patch \
     && patch -p1 < /usr/src/0001-Avoid-writing-to-system-console.patch \
     && ./script/setup \
     && apt-get purge -y --auto-remove \

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -1,4 +1,4 @@
-version: 0.2.6
+version: 0.3.0
 slug: openthread_border_router
 name: OpenThread Border Router
 description: OpenThread Border Router add-on
@@ -20,13 +20,13 @@ options:
   device: null
   baudrate: 115200
   flow_control: false
-  otbr_debug: false
+  otbr_log_level: notice
   firewall: true
 schema:
   device: device(subsystem=tty)
   baudrate: list(57600|115200|230400|460800|921600)
   flow_control: bool
-  otbr_debug: bool
+  otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
   firewall: bool
 stage: experimental
 startup: services

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -8,18 +8,20 @@ bashio::log.info "otbr-agent ended with exit code ${1} (signal ${2})..."
 
 ipset_destroy_if_exist()
 {
-    if ipset list "$1" 2> /dev/null; then
-        ipset destroy "$1"
-    fi
+    # The ipset seems to be in use by the kernel for a brief period,
+    # retry destroying it
+    while ipset list -n "$1" 2> /dev/null; do
+        ipset destroy "$1" || true
+    done
 }
 
 while ip6tables -C FORWARD -o $thread_if -j $otbr_forward_ingress_chain 2> /dev/null; do
-	ip6tables -D FORWARD -o $thread_if -j $otbr_forward_ingress_chain
+    ip6tables -D FORWARD -o $thread_if -j $otbr_forward_ingress_chain
 done
 
 if ip6tables -L $otbr_forward_ingress_chain 2> /dev/null; then
-	ip6tables -w -F $otbr_forward_ingress_chain
-	ip6tables -w -X $otbr_forward_ingress_chain
+    ip6tables -w -F $otbr_forward_ingress_chain
+    ip6tables -w -X $otbr_forward_ingress_chain
 fi
 
 ipset_destroy_if_exist otbr-ingress-deny-src
@@ -28,13 +30,14 @@ ipset_destroy_if_exist otbr-ingress-allow-dst
 ipset_destroy_if_exist otbr-ingress-allow-dst-swap
 
 while ip6tables -C FORWARD -i $thread_if -j $otbr_forward_egress_chain 2> /dev/null; do
-	ip6tables -D FORWARD -i $thread_if -j $otbr_forward_egress_chain
+    ip6tables -D FORWARD -i $thread_if -j $otbr_forward_egress_chain
 done
 
 if ip6tables -L $otbr_forward_egress_chain 2> /dev/null; then
-	ip6tables -w -F $otbr_forward_egress_chain
-	ip6tables -w -X $otbr_forward_egress_chain
+    ip6tables -w -F $otbr_forward_egress_chain
+    ip6tables -w -X $otbr_forward_egress_chain
 fi
+bashio::log.info "OTBR firewall teardown completed."
 
 if test "$1" -eq 256 ; then
   e=$((128 + $2))

--- a/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/openthread_border_router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -5,13 +5,14 @@
 
 . /etc/s6-overlay/scripts/otbr-agent-common
 
-declare otbr_agent_options
 declare backbone_if
 declare device
 declare baudrate
 declare flow_control
-backbone_if="$(bashio::api.supervisor 'GET' '/network/info' '' '.interfaces[] | select (.primary == true) | .interface')"
-otbr_agent_options="-d6 -v"
+declare otbr_log_level
+declare otbr_log_level_int
+
+backbone_if="$(bashio::api.supervisor 'GET' '/network/info' '' 'first(.interfaces[] | select (.primary == true)) .interface')"
 device=$(bashio::config 'device')
 baudrate=$(bashio::config 'baudrate')
 flow_control=""
@@ -20,9 +21,36 @@ if bashio::config.true 'flow_control'; then
     flow_control="&uart-flow-control"
 fi
 
-if bashio::config.true 'otbr_debug'; then
-    otbr_agent_options="-d7 -v"
-fi
+otbr_log_level=$(bashio::string.lower "$(bashio::config otbr_log_level)")
+case "${otbr_log_level}" in
+    debug)
+        otbr_log_level_int="7"
+        ;;
+    info)
+        otbr_log_level_int="6"
+        ;;
+    notice)
+        otbr_log_level_int="5"
+        ;;
+    warning)
+        otbr_log_level_int="4"
+        ;;
+    error)
+        otbr_log_level_int="3"
+        ;;
+    critical)
+        otbr_log_level_int="2"
+        ;;
+    alert)
+        otbr_log_level_int="1"
+        ;;
+    emergency)
+        otbr_log_level_int="0"
+        ;;
+    *)
+        bashio::exit.nok "Unknown otbr_log_level: ${otbr_log_level}"
+        ;;
+esac
 
 if [ -z ${backbone_if} ]; then
     bashio::log.warning "No primary network interface found! Using static eth0."
@@ -59,5 +87,5 @@ fi
 
 bashio::log.info "Starting otbr-agent..."
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 \
-    "/usr/sbin/otbr-agent" -I ${thread_if} -B "${backbone_if}" ${otbr_agent_options} \
+    "/usr/sbin/otbr-agent" -I ${thread_if} -B "${backbone_if}" -d${otbr_log_level_int} -v \
         "spinel+hdlc+uart://${device}?uart-baudrate=${baudrate}${flow_control}"

--- a/openthread_border_router/translations/en.yaml
+++ b/openthread_border_router/translations/en.yaml
@@ -8,9 +8,10 @@ configuration:
   flow_control:
     name: Hardware flow control
     description: Enable hardware flow control for serial port.
-  otbr_debug:
-    name: OpenThread agent debugging
-    description: Enable OpenThread agent debug output (otbr-agent).
+  otbr_log_level:
+    name: OpenThread Border Router agent log level
+    description: >-
+      Set logging level of the OpenThread Border Router agent (otbr-agent).
   firewall:
     name: OTBR firewall
     description: Use OpenThread Border Router firewall to block unnecessary traffic.


### PR DESCRIPTION
Bump OTBR add-on to 0.3.0 with the following changes:
- Bump to OTBR POSIX version 079bbce34a (2022-12-22 19:00:41 -0800)
- Add REST API with full active and pending dataset as well as state support
- Avoid start error in case multiple primary interfaces are returned
- Add fine grained OTBR log level control
- Fix service stop (finish) scripts