### PR TITLE
openthread_border_router: deprecate in favor of same add-on in main repo

### DIFF
--- a/openthread_border_router/README.md
+++ b/openthread_border_router/README.md
@@ -3,8 +3,8 @@
 OpenThread Border Router add-on. The add-on uses the upstream OpenThread
 Border Router implementation and wraps it as an add-on for Home Assistant.
 
-**NOTE:** This requires a supported 802.15.4 capable radio with OpenThread
-RCP firmware.
+**NOTE:** This add-on moved to the main repository. Please uninstall this
+add-on and install the same from the main repository.
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]

--- a/openthread_border_router/config.yaml
+++ b/openthread_border_router/config.yaml
@@ -39,7 +39,7 @@ schema:
   autoflash_firmware: bool
   otbr_log_level: list(debug|info|notice|warning|error|critical|alert|emergency)
   firewall: bool
-stage: experimental
+stage: deprecated
 startup: services
 panel_title: OpenThread
 panel_icon: mdi:view-grid-plus-outline


### PR DESCRIPTION
Related: https://github.com/home-assistant/addons/pull/2947