### PR TITLE
Bump Python version to 3.11 for custom deps

### DIFF
--- a/custom_deps/CHANGELOG.md
+++ b/custom_deps/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.4
+ - Update Python to 3.11
+
 ## 1.3.3
  - Fix: Addon don´t start
  - Fix: Addon don´t access config

--- a/custom_deps/build.yaml
+++ b/custom_deps/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.10-alpine3.16
-  i386: ghcr.io/home-assistant/i386-base-python:3.10-alpine3.16
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.10-alpine3.16
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.10-alpine3.16
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.10-alpine3.16
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18
+  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.18
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.18
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.18

--- a/custom_deps/config.yaml
+++ b/custom_deps/config.yaml
@@ -1,6 +1,6 @@
 name: Custom deps deployment
 init: false
-version: 1.3.3
+version: 1.3.4
 slug: custom_deps
 description: Manage custom Python modules in Home Assistant deps
 url: https://github.com/home-assistant/addons-development


### PR DESCRIPTION
Custom deps silently installed to `/config/deps/lib/python3.10/site-packages/` while Python's site directory is expected to be in `python3.11`.

Repeat of #80 but for python 3.11.
