### PR TITLE
Bump home-assistant/builder to 2024.03.5

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2024.01.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             ${{ env.BUILD_ARGS }} \


### PR DESCRIPTION
Bumps home-assistant/builder from [2024.01.0 to 2024.03.5](https://github.com/home-assistant/builder/compare/2024.01.0...2024.03.5).