### PR TITLE
chip_tool: Update to Matter v1.3

### DIFF
--- a/chip_tool/CHANGELOG.md
+++ b/chip_tool/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0
+
+- Bump to CHIP version/Matter SDK v1.3.0.0
+- This adds more examples, specifically:
+  - air-quality-sensor - Air quality sensor
+  - energy-management - Energy Management (specifically EVSE - Electric vehicle supply equipment)
+  - microwave-oven - Microwave Oven
+
 ## 0.3.1
 
 - Download pre-built examples instead of building using Docker

--- a/chip_tool/build.yaml
+++ b/chip_tool/build.yaml
@@ -4,4 +4,4 @@ build_from:
 args:
   LIBWEBSOCKETS_VERSION: 4.3.2
   TTYD_VERSION: 1.7.3
-  CHIP_VERSION: v1.2.0.1
+  CHIP_VERSION: v1.3.0.0

--- a/chip_tool/config.yaml
+++ b/chip_tool/config.yaml
@@ -1,4 +1,4 @@
-version: 0.3.1
+version: 0.4.0
 slug: chip_tool
 name: CHIP Tool
 description: Connected Home over IP (Matter) Tool example application.


### PR DESCRIPTION
This also deploys more examples as the source repository release has more examples enabled, see:
https://github.com/agners/matter-linux-example-apps/releases/tag/v1.3.0.0