### PR TITLE
Add mock for setback thermostat

### DIFF
--- a/zwave_mock_server/build.yaml
+++ b/zwave_mock_server/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.19
 args:
   ZWAVEJS_SERVER_VERSION: 1.38.0
-  ZWAVEJS_VERSION: 13.5.0
+  ZWAVEJS_VERSION: 13.7.0

--- a/zwave_mock_server/default_mock_files/010-thermostat-setback.js
+++ b/zwave_mock_server/default_mock_files/010-thermostat-setback.js
@@ -1,0 +1,19 @@
+/// This mock simulates a thermostat that only supports the Thermostat Setback CC
+
+// @ts-check
+const { CommandClasses } = require("@zwave-js/core");
+
+/** @type {import("zwave-js/Testing").MockServerOptions["config"]} */
+module.exports.default = {
+	nodes: [
+		{
+			id: 2,
+			capabilities: {
+				commandClasses: [
+					CommandClasses.Version,
+					CommandClasses["Thermostat Setback"],
+				],
+			},
+		},
+	],
+};


### PR DESCRIPTION
Adds a mock that can be used for https://github.com/zwave-js/certification-backlog/issues/15

This depends on a new driver release, so draft for now.