### PR TITLE
Bump chip-tool add-on to Matter 1.4.2

### DIFF
--- a/chip_tool/CHANGELOG.md
+++ b/chip_tool/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.5.0
+
+- Bump to CHIP version/Matter SDK v1.4.2.0
+- The following examples are included:
+  - air-purifier - Air purifier
+  - air-quality-sensor - Air purifier
+  - all-clusters - All clusters
+  - all-clusters-minimal - All clusters for minimal end device
+  - chip-cert - Certification tool
+  - chip-tool - Contact sensor
+  - contact-sensor-app - Contact sensor
+  - chip-dishwasher-app - Dishwasher
+  - energy-gateway - Electrical price of energy and grid conditions
+  - energy-management - Energy Management (specifically EVSE - Electric vehicle supply equipment and Water heater)
+  - light - Light
+  - lock - Lock
+  - microwave-oven - Microwave oven
+  - network-manager - Thread network manager
+  - ota-provider - Over-the-air update provider
+  - ota-requestor - Over-the-air update requestor
+  - refrigerator - Refrigerator
+  - rvc - Robotic Vacuum Cleaner
+  - terms-and-conditions - Terms-and-conditions during commissioning 
+  - thermostat - Thermostat
+  - tv-app - TV Example
+  - tv-casting-app - TV Casting app
+  - water-leak-detector - Water leak detector
+
 ## 0.4.0
 
 - Bump to CHIP version/Matter SDK v1.3.0.0

--- a/chip_tool/CHANGELOG.md
+++ b/chip_tool/CHANGELOG.md
@@ -9,7 +9,7 @@
   - all-clusters - All clusters
   - all-clusters-minimal - All clusters for minimal end device
   - chip-cert - Certification tool
-  - chip-tool - Contact sensor
+  - chip-tool - Controller implementation
   - contact-sensor-app - Contact sensor
   - chip-dishwasher-app - Dishwasher
   - energy-gateway - Electrical price of energy and grid conditions

--- a/chip_tool/build.yaml
+++ b/chip_tool/build.yaml
@@ -1,7 +1,7 @@
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
+  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
 args:
-  LIBWEBSOCKETS_VERSION: 4.3.2
-  TTYD_VERSION: 1.7.3
+  LIBWEBSOCKETS_VERSION: 4.3.5
+  TTYD_VERSION: 1.7.7
   CHIP_VERSION: v1.4.2.0

--- a/chip_tool/build.yaml
+++ b/chip_tool/build.yaml
@@ -4,4 +4,4 @@ build_from:
 args:
   LIBWEBSOCKETS_VERSION: 4.3.2
   TTYD_VERSION: 1.7.3
-  CHIP_VERSION: v1.3.0.0
+  CHIP_VERSION: v1.4.2.0

--- a/chip_tool/config.yaml
+++ b/chip_tool/config.yaml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.5.0
 slug: chip_tool
 name: CHIP Tool
 description: Connected Home over IP (Matter) Tool example application.


### PR DESCRIPTION
**Changes**
- Bump chip-tool add-on to Matter 1.4.2.
- Bump Debian version to bookworm
- Bump libwebsockets and ttyd versions

This also deploys more examples as the source repository release has more examples enabled, see:
https://github.com/agners/matter-linux-example-apps/releases/tag/v1.4.2.0

Fixes:
- https://github.com/home-assistant/addons-development/issues/187

