### PR TITLE
chip_tool: Fix terminal by enabling writeable mode by default

### DIFF
--- a/chip_tool/CHANGELOG.md
+++ b/chip_tool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- Fix terminal by enabling writeable mode explicitly
+
 ## 0.5.0
 
 - Bump to CHIP version/Matter SDK v1.4.2.0

--- a/chip_tool/config.yaml
+++ b/chip_tool/config.yaml
@@ -1,4 +1,4 @@
-version: 0.5.0
+version: 0.5.1
 slug: chip_tool
 name: CHIP Tool
 description: Connected Home over IP (Matter) Tool example application.

--- a/chip_tool/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/chip_tool/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -14,4 +14,4 @@ if bashio::config.true 'chip_debug'; then
     chip_repl_options="${chip_repl_options} -d"
 fi
 
-exec ttyd -p "${chip_repl_port}" -w /root tmux -u new-session -A -s homeassistant bash -l
+exec ttyd --writable -p "${chip_repl_port}" -w /root tmux -u new-session -A -s homeassistant bash -l


### PR DESCRIPTION
Since ttyd 1.7.4 the web terminal is by default read-only. Hence the terminal stopped taking any input with the bump to ttyd 1.7.7 in 0.5.0 version of this addon.

Fix this by passing `--writeable` by default.

Fixes: #189