### PR TITLE
Drop build for deprecated archs, use latest native runners

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -63,13 +63,17 @@ jobs:
           fi
   build:
     needs: init
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     if: needs.init.outputs.changed == 'true'
     name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
         arch: ["aarch64", "amd64"]
+        include:
+          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
 
     steps:
       - name: Check out repository
@@ -116,6 +120,7 @@ jobs:
         if: steps.check.outputs.build_arch == 'true'
         uses: home-assistant/builder@2025.11.0
         with:
+          image: ${{ matrix.arch }}
           args: |
             ${{ env.BUILD_ARGS }} \
             --${{ matrix.arch }} \

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        arch: ["aarch64", "amd64"]
 
     steps:
       - name: Check out repository

--- a/custom_deps/build.yaml
+++ b/custom_deps/build.yaml
@@ -1,6 +1,3 @@
 build_from:
   amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18
-  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.18
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.18
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.18
   aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.18

--- a/custom_deps/config.yaml
+++ b/custom_deps/config.yaml
@@ -5,11 +5,8 @@ slug: custom_deps
 description: Manage custom Python modules in Home Assistant deps
 url: https://github.com/home-assistant/addons-development
 arch:
-- armhf
-- armv7
 - aarch64
 - amd64
-- i386
 startup: once
 advanced: true
 homeassistant: 2021.7.0

--- a/remote_api/build.yaml
+++ b/remote_api/build.yaml
@@ -1,6 +1,3 @@
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
   aarch64: ghcr.io/home-assistant/aarch64-base:3.19
+  amd64: ghcr.io/home-assistant/amd64-base:3.19

--- a/remote_api/config.yaml
+++ b/remote_api/config.yaml
@@ -4,11 +4,8 @@ slug: remote_api
 description: Remote API proxy for Home Assistant
 url: https://developers.home-assistant.io/docs/supervisor/development/#supervisor-api-access
 arch:
-- armhf
-- armv7
 - aarch64
 - amd64
-- i386
 startup: once
 advanced: true
 stage: experimental

--- a/remote_debug/build.yaml
+++ b/remote_debug/build.yaml
@@ -1,6 +1,3 @@
 build_from:
   amd64: ghcr.io/home-assistant/amd64-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
   aarch64: ghcr.io/home-assistant/aarch64-base:3.19

--- a/remote_debug/config.yaml
+++ b/remote_debug/config.yaml
@@ -4,11 +4,8 @@ slug: remote_debug
 description: Remote Debug proxy for Supervisor/ptvsd
 url: https://developers.home-assistant.io/docs/supervisor/debugging
 arch:
-- armhf
-- armv7
 - aarch64
 - amd64
-- i386
 startup: once
 advanced: true
 stage: experimental

--- a/rt_test/README.md
+++ b/rt_test/README.md
@@ -2,9 +2,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 ## About
 
@@ -12,6 +9,3 @@ Utility to test Real-Time latency of Home Assistant.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/rt_test/build.yaml
+++ b/rt_test/build.yaml
@@ -1,9 +1,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.17
   amd64: ghcr.io/home-assistant/amd64-base:3.17
-  armhf: ghcr.io/home-assistant/armhf-base:3.17
-  armv7: ghcr.io/home-assistant/armv7-base:3.17
-  i386: ghcr.io/home-assistant/i386-base:3.17
 args:
   LIBWEBSOCKETS_VERSION: 4.3.2
   TTYD_VERSION: 1.7.3

--- a/rt_test/config.yaml
+++ b/rt_test/config.yaml
@@ -5,11 +5,8 @@ name: Real-Time latency test
 description: Testing Home Assistant latency using MQTT.
 url: https://github.com/home-assistant/addons-development/tree/master/rt_test
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 hassio_api: true
 image: homeassistant/{arch}-addon-rt-test
 init: false

--- a/skyconnect_cp2102n_programmer/README.md
+++ b/skyconnect_cp2102n_programmer/README.md
@@ -2,15 +2,9 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 
 ## About
 

--- a/skyconnect_cp2102n_programmer/build.yaml
+++ b/skyconnect_cp2102n_programmer/build.yaml
@@ -1,8 +1,5 @@
 build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-  i386: ghcr.io/home-assistant/i386-base-debian:bookworm
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
-  armhf: ghcr.io/home-assistant/armhf-base-debian:bookworm
 args:
   CP210X_CFG_COMMIT: b417a28b3367a65990ad501c6cb98da2c32b7ea4

--- a/skyconnect_cp2102n_programmer/config.yaml
+++ b/skyconnect_cp2102n_programmer/config.yaml
@@ -6,11 +6,8 @@ description: Program the manufacturer and vendor strings to a SkyConnect's CP210
 url: "https://github.com/home-assistant/addons-development/tree/master/skyconnect_cp2102n_programmer"
 image: homeassistant/{arch}-addon-skyconnect_cp2102n_programmer
 arch:
-  - armhf
-  - armv7
   - aarch64
   - amd64
-  - i386
 stage: experimental
 startup: once
 boot: manual


### PR DESCRIPTION
In #199 breaking bump of the builder action was merged. This means that future attempts at builds of deprecated architectures will fail. This change removes the deprecated architectures from the build matrix and changes the build job to use native runner for aarch64 build, while updating to latest runner versions as well.