### PR TITLE
Remove advanced flag from all configs

### DIFF
--- a/custom_deps/config.yaml
+++ b/custom_deps/config.yaml
@@ -8,7 +8,6 @@ arch:
 - aarch64
 - amd64
 startup: once
-advanced: true
 homeassistant: 2021.7.0
 stage: experimental
 boot: manual

--- a/remote_api/config.yaml
+++ b/remote_api/config.yaml
@@ -7,7 +7,6 @@ arch:
 - aarch64
 - amd64
 startup: once
-advanced: true
 stage: experimental
 boot: manual
 hassio_api: true

--- a/remote_debug/config.yaml
+++ b/remote_debug/config.yaml
@@ -7,7 +7,6 @@ arch:
 - aarch64
 - amd64
 startup: once
-advanced: true
 stage: experimental
 boot: manual
 ports:

--- a/zwave_mock_server/config.yaml
+++ b/zwave_mock_server/config.yaml
@@ -9,7 +9,6 @@ arch:
 map:
   - addon_config:rw
 init: false
-advanced: false
 stage: experimental
 tmpfs: true
 ports:


### PR DESCRIPTION
Refs https://github.com/home-assistant/addons/issues/4455

Note: Not bumping the `config.yaml` is not very clean, it causes a container rebuild but does not force an update on client side. But these are development apps, so I don't think we need to be too finical.