### PR TITLE
Harden workflows based on Zizmor check results

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,6 @@ updates:
     schedule:
       interval: weekly
       time: "06:00"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -22,13 +25,15 @@ jobs:
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed_files
-        uses: masesgroup/retrieve-changed-files@v4.0.0
+        uses: masesgroup/retrieve-changed-files@45a8b3b496d2d6037cbd553e8a3450989b9384a2 # v4.0.0
 
-      - name: Get add-ons
+      - name: Get apps
         id: addons
         run: |
           declare -a addons
@@ -37,14 +42,17 @@ jobs:
           done
           echo "addons=${addons[@]}" >> "$GITHUB_OUTPUT"
 
-      - name: Get changed add-ons
+      - name: Get changed apps
         id: changed_addons
+        env:
+          ADDONS: ${{ steps.addons.outputs.addons }}
+          CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
-          for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+          for addon in ${ADDONS}; do
+            if [[ "${CHANGED_FILES}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ "${CHANGED_FILES}" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi
@@ -55,17 +63,20 @@ jobs:
 
           changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
           if [[ -n ${changed} ]]; then
-            echo "Changed add-ons: $changed";
+            echo "Changed apps: $changed";
             echo "changed=true" >> "$GITHUB_OUTPUT";
             echo "addons=[$changed]" >> "$GITHUB_OUTPUT";
           else
-            echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
+            echo "No app had any monitored files changed (${{ env.MONITORED_FILES }})";
           fi
   build:
     needs: init
     runs-on: ${{ matrix.runs-on }}
     if: needs.init.outputs.changed == 'true'
     name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
@@ -77,40 +88,44 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@master # zizmor: ignore[unpinned-uses]
         with:
           path: "./${{ matrix.addon }}"
 
       - name: Check add-on
         id: check
+        env:
+          ADDON: ${{ matrix.addon }}
+          ARCHITECTURES: ${{ steps.info.outputs.architectures }}
+          BUILD_ARCH: ${{ matrix.arch }}
         run: |
-          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
+          if [[ "${ARCHITECTURES}" =~ ${BUILD_ARCH} ]]; then
              echo "build_arch=true" >> "$GITHUB_OUTPUT";
            else
-             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
+             echo "${BUILD_ARCH} is not a valid arch for ${ADDON}, skipping build";
           fi
 
       - name: Set build arguments
-        if: steps.check.outputs.build_arch == 'true'
+        if: steps.check.outputs.build_arch == 'true' && github.head_ref == '' && github.event_name == 'push'
         run: |
-          if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-              echo "BUILD_ARGS=--docker-hub-check" >> $GITHUB_ENV;
-          fi
+          echo "BUILD_ARGS=--docker-hub-check" >> "$GITHUB_ENV";
 
       - name: Login to DockerHub
         if: env.BUILD_ARGS == '--docker-hub-check'
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS == '--docker-hub-check'
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -118,7 +133,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.02.1
+        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
         with:
           image: ${{ matrix.arch }}
           args: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,13 +10,18 @@ on:
   push:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   hadolint:
     runs-on: ubuntu-latest
     name: hadolint
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run linter
         id: changed_files
@@ -33,7 +38,9 @@ jobs:
     name: JQ
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run linter
         run: |
@@ -44,7 +51,9 @@ jobs:
     name: ShellCheck
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run linter
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0


### PR DESCRIPTION
Make Zizmor happy by addressing all unpinned actions and potential injections. Dependabot cooldown uses the default of 7 days, this can be lowered later along with added custom Zizmor config.

Refs home-assistant/epics#29